### PR TITLE
remove active_job, active_record, and action_mailer from required frameworks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,10 +3,13 @@ require File.expand_path('../boot', __FILE__)
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
+#require "active_job/railtie"
+#NOTE: if active_record is added back, uncomment config.active_record.raise_in_transactional_callbacks
+# below, and ActiveRecord::Migration.maintain_test_schema! in spec/rails_helper.rb
+#require "active_record/railtie"
 require "action_controller/railtie"
-require "action_mailer/railtie"
+#NOTE: if action_mailer is added back, re-enable commented action_mailer config line in config/environments/test.rb
+#require "action_mailer/railtie"
 require "action_view/railtie"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
@@ -29,7 +32,8 @@ module DorIndexingApp
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # NOTE: only commented out because dor_indexing_app needs no DB yet.  uncomment this if that changes.
     # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
+    #config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,8 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  #NOTE: uncomment if action_mailer is re-enabled
+  #config.action_mailer.delivery_method = :test
 
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,7 +27,8 @@ Coveralls.wear!('rails')
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
+#NOTE: re-enable if active_record is re-enabled
+#ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
since this is supposed to be a slimmed down application focused on just indexing things from fedora to solr, and we want to be able to spin instances up easily to meet high indexing loads, it seems to make sense to not include things unnecessarily.

i imagine we won't be using the following in this app in the near future:
* active_job: i could see adding this back if we decide to have dor_indexing_app handle the bulk indexing that argo does now, though that's slightly trickier to extricate, and really what we want to do there is slim down the size of the workers that do the indexing, which doesn't necessarily mean moving it outside of argo.
* active_record: no need to do any database stuff at this point.  i get the impression that no session management is needed here, since authentication between dlss services seems to happen via IP whitelisting and/or certificate-based auth.
* action_mailer: no plans to send email.

there are notes as to what corresponding settings were commented out, since they would only be relevant to the things that were removed, and caused errors when trying to start the application without the frameworks to which they pertained.