### PR TITLE
various fixes to get deployment working

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -21,7 +21,7 @@ require 'capistrano/deploy'
 # require 'capistrano/rails/migrations'
 
 require 'capistrano/bundler'
-require 'capistrano/rails'
+# require 'capistrano/rails'  # most rails apps need this, but this one doesn't because there's no db to migrate, and there are no assets to precompile (https://github.com/capistrano/rails#usage)
 require 'capistrano/passenger'
 require 'dlss/capistrano'
 require 'squash/rails/capistrano3'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,5 +10,6 @@ set :home_directory, "/opt/app/#{fetch(:user)}"
 set :deploy_to, "#{fetch(:home_directory)}/#{fetch(:application)}"
 
 set :linked_dirs, %w(log config/settings tmp/pids tmp/cache tmp/sockets vendor/bundle)
+set :linked_files, %w(config/secrets.yml)
 
 before 'deploy:publishing', 'squash:write_revision'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 server 'dor-indexing-app-stage.stanford.edu', user: fetch(:user), roles: %w(web db app)
 
-set :rails_env, 'staging'
+set :rails_env, 'production'
 set :bundle_without, %w(test development).join(' ')
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,5 +63,6 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  #NOTE: not used since this app doesn't use a db
+  # config.active_record.dump_schema_after_migration = false
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -63,5 +63,6 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  #NOTE: not used since this app doesn't use a db
+  # config.active_record.dump_schema_after_migration = false
 end

--- a/config/initializers/squash_exceptions.rb
+++ b/config/initializers/squash_exceptions.rb
@@ -1,0 +1,8 @@
+# at present, we only use squash in -test and -prod.  but it has to
+# be configured to be disabled if we don't configure it with an api
+# key (which we don't have for dev).
+Squash::Ruby.configure api_host: Settings.SQUASH.API_HOST,
+                       api_key: Settings.SQUASH.API_KEY,
+                       environment: Settings.SQUASH_ENVIRONMENT || Rails.env,
+                       disabled: Settings.SQUASH.DISABLE,
+                       revision_file: File.join(Rails.root, 'REVISION')


### PR DESCRIPTION
* remove unused require and settings
 * remove "require 'capistrano/rails'" since it does asset:precomile and db:migrate, neither of which this app needs.
 * remove "config.active_record.dump_schema_after_migration" since we don't have a schema since we don't have a db.
* initialize Squash::Ruby.configure from settings
* stage should think its rails_env is production
* add secrets.yml to linked_files