### PR TITLE
middleware config to get is_it_working to give basic heartbeat status

### DIFF
--- a/config/initializers/is_it_working.rb
+++ b/config/initializers/is_it_working.rb
@@ -1,0 +1,4 @@
+require 'is_it_working'
+
+Rails.configuration.middleware.use(IsItWorking::Handler) do |h|
+end


### PR DESCRIPTION
this is required to provide the `/is_it_working` URL that makes the gem useful.

works on stage-lb, stage-a, and stage-b.  not showing up yet on stage, but that appears to be an issue of where the URL is pointing.