### PR TITLE
Redirect application root requests to is_it_working

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root to: redirect('/is_it_working')
 
   namespace :dor do
     # TODO: Deprecate GET when caml POST can be implemented


### PR DESCRIPTION
Not having a valid root resource can be confusing for diagnosing application problems.