### PR TITLE
update dor-services and other dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.7.1'
 gem 'squash_rails'
 gem 'squash_ruby'
 
-gem 'dor-services', '~> 5.10', '>= 5.10.1'
+gem 'dor-services', '>= 5.10.2', '< 6'
 gem 'is_it_working-cbeer'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,9 +79,9 @@ GEM
     capistrano-releaseboard (0.0.1)
       faraday
     concurrent-ruby (1.0.2)
-    config (1.2.1)
+    config (1.3.0)
       activesupport (>= 3.0)
-      deep_merge (~> 1.0, >= 1.0.1)
+      deep_merge (~> 1.1.1)
     confstruct (0.2.7)
     coveralls (0.8.15)
       json (>= 1.8, < 3)
@@ -105,7 +105,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.2.0)
       nokogiri
-    dor-services (5.10.1)
+    dor-services (5.10.2)
       active-fedora (~> 6.0)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
@@ -128,7 +128,7 @@ GEM
       ruby-graphviz
       rubydora (~> 1.6.5)
       solrizer (~> 3.0)
-      stanford-mods (= 1.5.3)
+      stanford-mods (>= 2.2.2)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
     dor-workflow-service (2.0.1)
@@ -236,7 +236,7 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.2.2)
+    rake (11.3.0)
     rdf (1.1.17.1)
       link_header (~> 0.0, >= 0.0.8)
     rdf-rdfxml (1.0.1)
@@ -309,10 +309,10 @@ GEM
       squash_ruby
     squash_ruby (2.0.1)
       json
-    sshkit (1.11.2)
+    sshkit (1.11.3)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (1.5.3)
+    stanford-mods (2.2.2)
       activesupport
       mods (~> 2.0.2)
     stomp (1.4.3)
@@ -343,7 +343,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano (~> 3.0)
-  dor-services (~> 5.10, >= 5.10.1)
+  dor-services (>= 5.10.2, < 6)
   is_it_working-cbeer
   rails (= 4.2.7.1)
   rspec-rails (~> 3.0)


### PR DESCRIPTION
update to the latest dor-services (5.10.2) so that we can get the version that uses the latest stanford-mods (2.2.2), so that indexing of searchworks genre field matches present searchworks indexing behavior.