### PR TITLE
update to latest dor-services (5.11.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'squash_rails'
 gem 'squash_ruby'
 gem 'rack-timeout'
 
-gem 'dor-services', '>= 5.10.3', '< 6'
+gem 'dor-services', '>= 5.11.1', '< 6'
 gem 'is_it_working-cbeer'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.2.0)
       nokogiri
-    dor-services (5.10.3)
+    dor-services (5.11.1)
       active-fedora (~> 6.0)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
@@ -149,7 +149,7 @@ GEM
       activesupport (>= 4.1.0)
     hooks (0.3.6)
       uber (~> 0.0.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     is_it_working-cbeer (1.0.16)
@@ -344,7 +344,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano (~> 3.0)
-  dor-services (>= 5.10.3, < 6)
+  dor-services (>= 5.11.1, < 6)
   is_it_working-cbeer
   rack-timeout
   rails (= 4.2.7.1)
@@ -353,4 +353,4 @@ DEPENDENCIES
   squash_ruby
 
 BUNDLED WITH
-   1.13.1
+   1.13.2


### PR DESCRIPTION
the latest version of dor-services fixes `Releaseable#to_solr` so that it only puts targets to which the object has actually been released in the `released_to_ssim` field.