### PR TITLE
[WIP] Pass through a commitWithin parameter instead of unconditionally commiting

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -1,7 +1,7 @@
 class DorController < ApplicationController
   def reindex
-    @solr_doc = Dor::IndexingService.reindex_pid params[:pid], Dor::IndexingService.generate_index_logger { request.uuid }
-    Dor::SearchService.solr.commit # reindex_pid doesn't commit, but callers of this method may expect the update to be committed immediately
+    @solr_doc = Dor::IndexingService.reindex_pid params[:pid], logger: Dor::IndexingService.generate_index_logger { request.uuid }, add_attributes: { commitWithin: params.fetch(:commitWithin, 1000).to_i }
+    Dor::SearchService.solr.commit unless params[:commitWithin] # reindex_pid doesn't commit, but callers of this method may expect the update to be committed immediately
     render status: 200, text: "Successfully updated index for #{params[:pid]}"
   rescue ActiveFedora::ObjectNotFoundError # => e
     render status: 404, text: 'Object does not exist in Fedora.'

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DorController, type: :controller do
 
     it 'should reindex an object' do
       expect(Dor::IndexingService).to receive(:reindex_pid)
-        .with(@mock_druid, @mock_logger).and_return(@mock_solr_doc)
+        .with(@mock_druid, logger: @mock_logger, add_attributes: { commitWithin: 1000 }).and_return(@mock_solr_doc)
       expect(Dor::SearchService).to receive(:solr).and_return(@mock_solr_conn)
       expect(@mock_solr_conn).to receive(:commit)
       get :reindex, pid: @mock_druid
@@ -21,9 +21,18 @@ RSpec.describe DorController, type: :controller do
       expect(response.code).to eq '200'
     end
 
+    it 'can be used with asynchronous commits' do
+      expect(Dor::IndexingService).to receive(:reindex_pid)
+        .with(@mock_druid, logger: @mock_logger, add_attributes: { commitWithin: 2 }).and_return(@mock_solr_doc)
+      expect(Dor::SearchService).not_to receive(:solr)
+      get :reindex, pid: @mock_druid, commitWithin: 2
+      expect(response.body).to eq "Successfully updated index for #{@mock_druid}"
+      expect(response.code).to eq '200'
+    end
+
     it 'should give the right status if an object is not found' do
       expect(Dor::IndexingService).to receive(:reindex_pid)
-        .with(@mock_druid, @mock_logger).and_raise(ActiveFedora::ObjectNotFoundError)
+        .with(@mock_druid, logger: @mock_logger, add_attributes: { commitWithin: 1000 }).and_raise(ActiveFedora::ObjectNotFoundError)
       get :reindex, pid: @mock_druid
       expect(response.body).to eq 'Object does not exist in Fedora.'
       expect(response.code).to eq '404'


### PR DESCRIPTION
Depends on https://github.com/sul-dlss/dor-services/pull/241

Used by e.g. https://github.com/sul-dlss/dor-camel-routes/pull/5.