### PR TITLE
port monitoring from is_it_working to OkComputer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'honeybadger', '~> 2.0'
 gem 'rack-timeout'
 
 gem 'dor-services', '>= 5.11.1', '< 6'
-gem 'is_it_working-cbeer'
+gem 'okcomputer' # for monitoring
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,6 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    is_it_working-cbeer (1.0.16)
     iso-639 (0.2.8)
     json (1.8.3)
     link_header (0.0.8)
@@ -208,6 +207,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
+    okcomputer (1.13.0)
     om (3.1.1)
       activemodel
       activesupport
@@ -357,11 +357,11 @@ DEPENDENCIES
   dlss-capistrano (~> 3.0)
   dor-services (>= 5.11.1, < 6)
   honeybadger (~> 2.0)
-  is_it_working-cbeer
   newrelic_rpm
+  okcomputer
   rack-timeout
   rails (= 4.2.7.1)
   rspec-rails (~> 3.0)
 
 BUNDLED WITH
-   1.13.3
+   1.13.6

--- a/config/initializers/is_it_working.rb
+++ b/config/initializers/is_it_working.rb
@@ -1,8 +1,0 @@
-require 'is_it_working'
-
-unless Rails.env == 'test'
-  Rails.configuration.middleware.use(IsItWorking::Handler) do |h|
-    h.check :rubydora, :client => ActiveFedora::Base.connection_for_pid(0)
-    h.check :rsolr, :client => Dor::SearchService.solr
-  end
-end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -20,7 +20,7 @@ OkComputer::Registry.register 'version', VersionCheck.new
 ##
 # EXTERNAL Services
 
-OkComputer::Registry.register 'external-solr', OkComputer::SolrCheck.new(Dor::SearchService.solr.uri.to_s)
+OkComputer::Registry.register 'external-solr', OkComputer::SolrCheck.new(Dor::SearchService.solr.uri.to_s.gsub(/\/$/, ''))
 
 # Simple check to ping the Fedora server by asking it to describe the repository
 class FedoraCheck < OkComputer::Check

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,37 @@
+require 'okcomputer'
+
+OkComputer.mount_at = 'status' # use /status or /status/all or /status/<name-of-check>
+OkComputer.check_in_parallel = true
+OkComputer::Registry.deregister 'database' # we don't have a database
+
+##
+# REQUIRED checks
+
+# Simple echo of the VERSION file
+class VersionCheck < OkComputer::AppVersionCheck
+  def version
+    File.read(Rails.root.join('VERSION')).chomp
+  rescue Errno::ENOENT
+    raise UnknownRevision
+  end
+end
+OkComputer::Registry.register 'version', VersionCheck.new
+
+##
+# EXTERNAL Services
+
+OkComputer::Registry.register 'external-solr', OkComputer::SolrCheck.new(Dor::SearchService.solr.uri.to_s)
+
+# Simple check to ping the Fedora server by asking it to describe the repository
+class FedoraCheck < OkComputer::Check
+  def check
+    conn = ActiveFedora::Base.connection_for_pid(0)
+    profile = conn.repository_profile # use vs. `profile` to force a GET call to the server for `/fedora/describe`
+    mark_message "Connected to #{profile['repositoryName']} #{profile['repositoryVersion']} via Rubydora #{Rubydora::VERSION}"
+  rescue => e
+    mark_failure
+    mark_message "Failure: #{e.class.name}: #{e.message}"
+  end
+end
+
+OkComputer::Registry.register 'external-fedora', FedoraCheck.new


### PR DESCRIPTION
This PR fixes #48. It doesn't do *exactly* the same thing as the is_it_working implementation but it's close. Notably, the Fedora check now forces a GET from the Fedora server rather than using a cached value (that was internal to Rubydora gem).

NOTE that I wasn't able to test the `/status/external-solr` endpoint fully due to firewall restrictions. We'll need to deploy to stage to test that piece.