### PR TITLE
update to dor-services 5.14.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ gem 'honeybadger', '~> 2.0'
 gem 'rack-timeout'
 gem 'faraday'
 
-gem 'dor-services', '>= 5.11.1', '< 6'
+gem 'active-fedora', '~> 6.8' # stay on 6.x until we can test further
+gem 'dor-services', '~> 5.14'
 gem 'okcomputer' # for monitoring
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
-    bagit (0.3.2)
+    bagit (0.3.4)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     builder (3.2.2)
@@ -105,12 +105,12 @@ GEM
       capistrano-shared_configs
     docile (1.1.5)
     docopt (0.5.0)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20161021)
       unf (>= 0.0.5, < 1.0.0)
-    dor-rights-auth (1.2.0)
+    dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.12.0)
-      active-fedora (~> 6.0)
+    dor-services (5.14.0)
+      active-fedora (>= 6.0, < 9.a)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
       dor-rights-auth (~> 1.0, >= 1.2.0)
@@ -353,6 +353,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active-fedora (~> 6.8)
   activemodel (~> 5.0.0)
   capistrano (~> 3.0)
   capistrano-bundler
@@ -362,7 +363,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano (~> 3.0)
-  dor-services (>= 5.11.1, < 6)
+  dor-services (~> 5.14)
   faraday
   honeybadger (~> 2.0)
   newrelic_rpm


### PR DESCRIPTION
This PR fixes #25 by upgrading to dor-services 5.14.0 so that we can pull in the new rights indexing. See https://github.com/sul-dlss/dor-services/releases/tag/v5.14.0.

I left ActiveFedora at 6.8.0, otherwise it upgrades to 8.x.