### PR TITLE
Expose the combined total of queued messages from all the message queue services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rails', '4.2.7.1'
 gem 'activemodel', '4.2.7.1'
 gem 'honeybadger', '~> 2.0'
 gem 'rack-timeout'
+gem 'faraday'
 
 gem 'dor-services', '>= 5.11.1', '< 6'
 gem 'okcomputer' # for monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano (~> 3.0)
   dor-services (>= 5.11.1, < 6)
+  faraday
   honeybadger (~> 2.0)
   newrelic_rpm
   okcomputer

--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -6,4 +6,8 @@ class DorController < ApplicationController
   rescue ActiveFedora::ObjectNotFoundError # => e
     render status: 404, text: 'Object does not exist in Fedora.'
   end
+
+  def queue_size
+    render status: 200, json: { value: QueueStatus.all.queue_size }
+  end
 end

--- a/app/models/queue_status.rb
+++ b/app/models/queue_status.rb
@@ -1,0 +1,34 @@
+class QueueStatus
+  def self.all
+    All.new(find_each)
+  end
+  
+  def self.find_each
+    return to_enum(:find_each) unless block_given?
+    Settings.MESSAGE_QUEUES.each do |mq|
+      yield new(queue_size_url: mq.QUEUE_SIZE_URL)
+    end
+  end
+  
+  attr_reader :queue_size_url
+
+  def initialize(queue_size_url:)
+    @queue_size_url = queue_size_url
+  end
+
+  def queue_size
+    response = Faraday.get(queue_size_url)
+    data = JSON.parse(response)
+    data['value']
+  end
+  
+  class All
+    def initialize(queues = [])
+      @queues = queues.to_a
+    end
+    
+    def queue_size
+      @queues.map(&:queue_size).sum
+    end
+  end
+end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -35,3 +35,7 @@ class FedoraCheck < OkComputer::Check
 end
 
 OkComputer::Registry.register 'external-fedora', FedoraCheck.new
+
+OkComputer::Registry.register 'external-queue-size', (OkComputer::SizeThresholdCheck.new('Total queue size', 50000) do
+  QueueStatus.all.queue_size
+end)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
   namespace :dor do
     # TODO: Deprecate GET when caml POST can be implemented
     match 'reindex/:pid', action: :reindex, via: [:get, :post, :put]
+    get 'queue_size'
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,6 +54,8 @@ WORKFLOW:
   LOGFILE: 'log/workflow_service.log'
   SHIFT_AGE: 'weekly'
 
+MESSAGE_QUEUES: []
+
 # URLs
 DOR_SERVICES_URL: 'https://user:password@dor-services.example.com'
 FEDORA_URL: 'https://user:password@fedora.example.com:1000/fedora'

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -38,4 +38,13 @@ RSpec.describe DorController, type: :controller do
       expect(response.code).to eq '404'
     end
   end
+
+  describe '#queue_size' do
+    let(:mock_status) { instance_double(QueueStatus::All, queue_size: 15) }
+    it 'retrives the size of the backing message queues' do
+      expect(QueueStatus).to receive(:all).and_return(mock_status)
+      get :queue_size
+      expect(JSON.parse(response.body)).to include('value' => 15)
+    end
+  end
 end

--- a/spec/models/queue_status_spec.rb
+++ b/spec/models/queue_status_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe QueueStatus do
+  let(:queue_size_url) { 'http://example.com/queue/size' }
+  let(:mock_response) { { 'value' => 123 }.to_json }
+
+  before do
+    allow(Faraday.default_connection).to receive(:get).with(queue_size_url).and_return(mock_response)
+  end
+  subject(:queue_status) { QueueStatus.new(queue_size_url: queue_size_url) }
+
+  describe '#queue_size' do
+
+    it 'retrieves the queue size' do
+      expect(subject.queue_size).to eq 123
+    end
+  end
+  
+  describe '.all' do
+    subject { QueueStatus.all }
+
+    let(:queue) { double(QUEUE_SIZE_URL: queue_size_url) }
+
+    before do
+      allow(Settings).to receive(:MESSAGE_QUEUES).and_return([queue, queue])
+    end
+
+    describe '#queue_size' do
+      it 'sums the queue sizes of all the message queues' do
+        expect(subject.queue_size).to eq 246
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Add `/dor/queue_size` route
- [x] Add okcomputer check with a generous threshold (50k messages) 