### PR TITLE
Work-around to support basic auth for message queue size endpoint

### DIFF
--- a/app/models/queue_status.rb
+++ b/app/models/queue_status.rb
@@ -17,8 +17,8 @@ class QueueStatus
   end
 
   def queue_size
-    response = Faraday.get(queue_size_url)
-    data = JSON.parse(response)
+    client = Faraday.new(queue_size_url)
+    data = JSON.parse(client.get.body)
     data['value']
   end
   

--- a/spec/models/queue_status_spec.rb
+++ b/spec/models/queue_status_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe QueueStatus do
   let(:queue_size_url) { 'http://example.com/queue/size' }
-  let(:mock_response) { { 'value' => 123 }.to_json }
+  let(:mock_response) { instance_double(Faraday::Response, body: { 'value' => 123 }.to_json) }
+  let(:mock_client) { instance_double(Faraday::Connection, get: mock_response) }
 
   before do
-    allow(Faraday.default_connection).to receive(:get).with(queue_size_url).and_return(mock_response)
+    allow(Faraday).to receive(:new).with(queue_size_url).and_return(mock_client)
   end
   subject(:queue_status) { QueueStatus.new(queue_size_url: queue_size_url) }
 


### PR DESCRIPTION
Fixes #75 

Turns out `Faraday.get(url)` doesn't handle basic auth, so we have to do `Faraday.new(url).get` instead.