### PR TITLE
add scriptie to generate timings from log/indexer.log

### DIFF
--- a/script/parse_indexing_log.rb
+++ b/script/parse_indexing_log.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+#
+# parses an `indexer.log` and outputs a CSV file of the timings.
+#
+# The data output are the real time as `:real` and percentage of time
+# spend idle as `:pct_idle` (e.g., waiting for network requests), for
+# the time it takes to read the core data from Fedora into an object
+# `load:` and the time it takes to convert that object into a solr
+# document `:to_solr`
+#
+# Usage: script/parse_indexing_log.rb [log/indexing.log ...] > data.csv
+#
+puts %w(druid load:real load:pct_idle to_solr:real to_solr:pct_idle total:real).join(',')
+
+ARGF.lines do |line|
+  matches = %r{successfully updated index for druid:([a-z0-9]+).+metrics: load_instance realtime ([\d\.]+)s total CPU ([\d\.]+)s; to_solr realtime ([\d\.]+)s total CPU ([\d\.]+)s}.match(line)
+  if matches
+    druid, load_real, load_cpu, solr_real, solr_cpu = matches[1..5]
+    record = [
+      druid,
+      load_real,
+      "%0.3f" % (100 * (load_real.to_f - load_cpu.to_f)/(load_real.to_f)),
+      solr_real,
+      "%0.3f" % (100 * (solr_real.to_f - solr_cpu.to_f)/(solr_real.to_f)),
+      "%0.6f" % (load_real.to_f + solr_real.to_f)
+    ]
+    puts record.join(',')
+  end
+end


### PR DESCRIPTION
This PR is connected to #67 and adds a scriptie that parses `log/indexer.log` and outputs a CSV with internal timings for realtime and percentage idle for both the `load_instance` and `to_solr` phases of the indexing. This log output is supported in `dor-services` v5.14.2.

Usage is 

```
% cd dor_indexing_app/current
% script/parse_indexing_log.rb log/indexing.log
```

The output looks like this:

```
druid,load:real,load:pct_idle,to_solr:real,to_solr:pct_idle,total:real
sj305rz0432,0.702535,11.748,2.756620,27.447,3.459155
bk560pg8201,0.304924,27.851,1.330316,26.333,1.635240
nf483fx5396,0.290778,31.219,2.437451,29.434,2.728229
km409rc0851,0.944900,12.160,2.686266,29.270,3.631166
tb213bx7240,0.332670,21.844,1.457210,32.748,1.789880
qk306hh1567,1.094226,9.525,2.709004,31.340,3.803230
bk560pg8201,0.305944,31.360,1.469999,32.653,1.775943
nz716yf0097,0.265554,32.217,1.341484,25.456,1.607038
km409rc0851,0.306505,24.960,1.534210,32.864,1.840715
rz920tb9915,0.293555,25.057,2.238528,55.775,2.532083
wt877mk7756,0.308444,25.432,2.408576,57.651,2.717020
tb213bx7240,0.290413,20.802,1.687811,43.122,1.978224
```