### PR TITLE
Bump dor-services to 5.32.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.31.1)
+    dor-services (5.32.0)
       active-fedora (>= 7.0, < 9.a)
       activesupport (>= 4.2.10, < 5.2.0)
       confstruct (~> 0.2.7)


### PR DESCRIPTION
This should prevent a nil pointer error https://github.com/sul-dlss/dor_indexing_app/issues/138
which is guarded against in https://github.com/sul-dlss/dor-services/pull/367