### PR TITLE
fix how we pass optional params to rsolr

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 55
+  Max: 59
 
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -45,7 +45,7 @@ class DorController < ApplicationController
     # benchmark how long it takes to convert the object to a Solr document
     to_solr_stats = Benchmark.measure('to_solr') do
       solr_doc = obj.to_solr
-      solr.add(solr_doc, add_attributes)
+      solr.add(solr_doc, add_attributes: add_attributes)
     end.format('%n realtime %rs total CPU %ts').gsub(/[\(\)]/, '')
 
     logger.info "successfully updated index for #{pid} (metrics: #{load_stats}; #{to_solr_stats})"

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -14,10 +14,18 @@ RSpec.describe DorController, type: :controller do
     let(:mock_druid) { 'asdf:1234' }
     let(:mock_solr_doc) { { id: mock_druid, text_field_tesim: 'a field to be searched' } }
 
-    it 'reindexes an object' do
+    it 'reindexes an object with default commitWithin param and a hard commit' do
       get :reindex, params: { pid: mock_druid }
-      expect(mock_solr_conn).to have_received(:add)
+      expect(mock_solr_conn).to have_received(:add).with({ id: 'asdf:1234', text_field_tesim: 'a field to be searched' }, add_attributes: { commitWithin: 1000 })
       expect(mock_solr_conn).to have_received(:commit)
+      expect(response.body).to eq "Successfully updated index for #{mock_druid}"
+      expect(response.code).to eq '200'
+    end
+
+    it 'reindexes an object with specified commitWithin param and no hard commit' do
+      get :reindex, params: { pid: mock_druid, commitWithin: 10000 }
+      expect(mock_solr_conn).to have_received(:add).with({ id: 'asdf:1234', text_field_tesim: 'a field to be searched' }, add_attributes: { commitWithin: 10000 })
+      expect(mock_solr_conn).not_to have_received(:commit)
       expect(response.body).to eq "Successfully updated index for #{mock_druid}"
       expect(response.code).to eq '200'
     end


### PR DESCRIPTION
fixes #297 

The optional param of "commitWithin" was never making it to solr.

According to https://github.com/rsolr/rsolr/blob/master/README.rdoc under "Updating Solr" indicates we need to a pass a the params like this:

`solr.add documents, :add_attributes => {:commitWithin => 10}`

and not like we were doing like this:

`solr.add documents, {:commitWithin => 10}`