### PR TITLE
Look-up status code to normalize processing statuses

### DIFF
--- a/app/indexers/processable_indexer.rb
+++ b/app/indexers/processable_indexer.rb
@@ -37,7 +37,7 @@ class ProcessableIndexer
     solr_doc['status_ssi'] = status_service.display
     status_info_hash = status_service.info
     status_code = status_info_hash[:status_code]
-    add_solr_value(solr_doc, 'processing_status_text', simplified_status_code_disp_txt(status_service.display), :string, [:stored_sortable])
+    add_solr_value(solr_doc, 'processing_status_text', simplified_status_code_disp_txt(status_code), :string, [:stored_sortable])
     solr_doc['processing_status_code_isi'] = status_code
   end
 
@@ -92,7 +92,7 @@ class ProcessableIndexer
 
   # @return [String] text translation of the status code, minus any trailing parenthetical explanation
   # e.g. 'In accessioning (described)' and 'In accessioning (described, published)' both return 'In accessioning'
-  def simplified_status_code_disp_txt(display)
-    display.gsub(/\(.*\)$/, '').strip
+  def simplified_status_code_disp_txt(status_code)
+    Dor::Workflow::Client::Status::STATUS_CODE_DISP_TXT[status_code].gsub(/\(.*\)$/, '').strip
   end
 end

--- a/spec/indexers/processable_indexer_spec.rb
+++ b/spec/indexers/processable_indexer_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe ProcessableIndexer do
     end
 
     it "trims off parens but doesn't harm the strings otherwise" do
-      expect(indexer.send(:simplified_status_code_disp_txt, 'In accessioning (described)')).to eq('In accessioning')
-      expect(indexer.send(:simplified_status_code_disp_txt, 'In accessioning (described, published)')).to eq('In accessioning')
+      expect(indexer.send(:simplified_status_code_disp_txt, 2)).to eq('In accessioning')
+      expect(indexer.send(:simplified_status_code_disp_txt, 3)).to eq('In accessioning')
     end
   end
 


### PR DESCRIPTION
Fixes sul-dlss/argo#1795

Reverts part of [368c76cc9ce528e0dbf71f2165f02f1c24bd2abf](https://github.com/sul-dlss/dor_indexing_app/commit/368c76cc9ce528e0dbf71f2165f02f1c24bd2abf), which caused version numbers to leak into processing statuses.

Cc: @andrewjbtw @jcoyne 