### PR TITLE
Use ReleaseTags::IdentityMetadata for getting tags

### DIFF
--- a/app/indexers/releasable_indexer.rb
+++ b/app/indexers/releasable_indexer.rb
@@ -27,6 +27,6 @@ class ReleasableIndexer
   private
 
   def released_for
-    Dor::ReleaseTagService.for(resource).released_for(skip_live_purl: true)
+    Dor::ReleaseTags::IdentityMetadata.for(resource).released_for({})
   end
 end

--- a/spec/indexers/releasable_indexer_spec.rb
+++ b/spec/indexers/releasable_indexer_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe ReleasableIndexer do
         'test_nontarget' => { 'release' => false }
       }
     end
-    let(:service) { instance_double(Dor::ReleaseTagService, released_for: released_for_info) }
+    let(:service) { instance_double(Dor::ReleaseTags::IdentityMetadata, released_for: released_for_info) }
     let(:released_to_field_name) { Solrizer.solr_name('released_to', :symbol) }
 
     before do
-      allow(Dor::ReleaseTagService).to receive(:for).and_return(service)
+      allow(Dor::ReleaseTags::IdentityMetadata).to receive(:for).and_return(service)
     end
 
     it 'indexes release tags' do


### PR DESCRIPTION
This will allow us to remove ReleaseTagService from dor-services and with it a dependency on PURL. The PURL dependency is only used in dor-services-app, so we can move it there.  Since dor_indexing_app was always passing `skip_live_purl: true`, that logic was always bypassed.