### PR TITLE
Use dor-services-client to list release tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'rack-timeout', '~> 0.5.1'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'dor-services', '~> 8.3'
+gem 'dor-services-client', '~> 4.11'
 gem 'dor-workflow-client', '~> 3.20'
 gem 'okcomputer' # for monitoring
 gem 'rsolr', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,11 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    concurrent-ruby (1.1.5)
+    cocina-models (0.15.0)
+      dry-struct (~> 1.0)
+      dry-types (~> 1.1)
+      zeitwerk (~> 2.1)
+    concurrent-ruby (1.1.6)
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
@@ -135,6 +139,12 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
+    dor-services-client (4.11.0)
+      activesupport (>= 4.2, < 7)
+      cocina-models (~> 0.15.0)
+      faraday (~> 0.15)
+      moab-versioning (~> 4.0)
+      zeitwerk (~> 2.1)
     dor-workflow-client (3.20.1)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
@@ -155,7 +165,7 @@ GEM
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
     dry-initializer (3.0.3)
-    dry-logic (1.0.5)
+    dry-logic (1.0.6)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
@@ -167,7 +177,12 @@ GEM
       dry-initializer (~> 3.0)
       dry-logic (~> 1.0)
       dry-types (~> 1.2)
-    dry-types (1.2.2)
+    dry-struct (1.3.0)
+      dry-core (~> 0.4, >= 0.4.4)
+      dry-equalizer (~> 0.3)
+      dry-types (~> 1.3)
+      ice_nine (~> 0.11)
+    dry-types (1.3.0)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
       dry-core (~> 0.4, >= 0.4.4)
@@ -206,6 +221,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     iso-639 (0.2.8)
     jaro_winkler (1.5.4)
     json (2.3.0)
@@ -225,6 +241,11 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
+    moab-versioning (4.4.0)
+      druid-tools (>= 1.0.0)
+      json
+      nokogiri
+      nokogiri-happymapper
     mods (2.4.1)
       edtf
       iso-639
@@ -239,8 +260,10 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.8.0.360)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
+    nokogiri-happymapper (0.8.1)
+      nokogiri (~> 1.5)
     nom-xml (1.1.0)
       activesupport (>= 3.2.18)
       i18n
@@ -423,6 +446,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano (~> 3.0)
   dor-services (~> 8.3)
+  dor-services-client (~> 4.11)
   dor-workflow-client (~> 3.20)
   erubis
   faraday

--- a/app/indexers/releasable_indexer.rb
+++ b/app/indexers/releasable_indexer.rb
@@ -4,6 +4,7 @@ class ReleasableIndexer
   include SolrDocHelper
 
   attr_reader :resource
+
   def initialize(resource:)
     @resource = resource
   end
@@ -27,6 +28,10 @@ class ReleasableIndexer
   private
 
   def released_for
-    Dor::ReleaseTags::IdentityMetadata.for(resource).released_for({})
+    object_client.release_tags.list
+  end
+
+  def object_client
+    Dor::Services::Client.object(resource.pid)
   end
 end

--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Configure dor-services-client to use the dor-services URL
+Dor::Services::Client.configure(url: Settings.dor_services.url,
+                                token: Settings.dor_services.token)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,3 +48,7 @@ MESSAGE_QUEUES: []
 FEDORA_URL: 'https://user:password@fedora.example.com:1000/fedora'
 SOLRIZER_URL: 'https://solr.example.com/solr/collection'
 WORKFLOW_URL: 'https://workflow.example.edu/'
+
+dor_services:
+  url: 'http://localhost:3003'
+  token: 'not-a-real-token'

--- a/spec/indexers/releasable_indexer_spec.rb
+++ b/spec/indexers/releasable_indexer_spec.rb
@@ -3,11 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe ReleasableIndexer do
-  let(:obj) { instance_double(Dor::Abstract) }
+  let(:obj) { instance_double(Dor::Abstract, pid: 'druid:pz263ny9658') }
 
   describe 'to_solr' do
     let(:doc) { described_class.new(resource: obj).to_solr }
-
     let(:released_for_info) do
       {
         'Project' => { 'release' => true },
@@ -15,15 +14,16 @@ RSpec.describe ReleasableIndexer do
         'test_nontarget' => { 'release' => false }
       }
     end
-    let(:service) { instance_double(Dor::ReleaseTags::IdentityMetadata, released_for: released_for_info) }
     let(:released_to_field_name) { Solrizer.solr_name('released_to', :symbol) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, release_tags: tags_client) }
+    let(:tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: released_for_info) }
 
     before do
-      allow(Dor::ReleaseTags::IdentityMetadata).to receive(:for).and_return(service)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     end
 
     it 'indexes release tags' do
-      expect(doc).to match a_hash_including(released_to_field_name => %w[Project test_target])
+      expect(doc).to eq(released_to_field_name => %w[Project test_target])
     end
   end
 end


### PR DESCRIPTION
Fixes #336
Fixes sul-dlss/google-books#283

This PR removes one point of contact between dor_indexing_app and DOR/Fedora, advancing a key objective of SDR evolution. Note: temporarily blocked by https://github.com/sul-dlss/shared_configs/pull/1203 and https://github.com/sul-dlss/shared_configs/pull/1204