### PR TITLE
unpin iso-639 gem -- issue that necessitated pinning has been fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,6 @@ gem 'erubis'
 gem 'config'
 gem 'faraday'
 gem 'honeybadger', '~> 4.5'
-# iso-639 0.3.0 isn't compatible with ruby 2.5.  This declaration can be dropped when we upgrade to ruby 2.6
-# see https://github.com/alphabetum/iso-639/issues/12
-gem 'iso-639', '~> 0.2.10'
 gem 'rack-timeout', '~> 0.5.1'
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    iso-639 (0.2.10)
+    iso-639 (0.3.3)
     jaro_winkler (1.5.4)
     json (2.3.0)
     link_header (0.0.8)
@@ -458,7 +458,6 @@ DEPENDENCIES
   erubis
   faraday
   honeybadger (~> 4.5)
-  iso-639 (~> 0.2.10)
   listen (~> 3.0.5)
   newrelic_rpm
   okcomputer


### PR DESCRIPTION
see https://github.com/alphabetum/iso-639/issues/12

## Why was this change made?

i was going to crib from https://github.com/sul-dlss/dor_indexing_app/pull/356/files to fix the preservation_robots build that broke due to the above mentioned iso-639 bug.  but then when clicking through i noticed the bug had been fixed for ruby 2.5.  so i just upgraded pres robots again, and since that worked, i'm unpinning here, since the pinning no longer seems necessary.


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

yes (comment that went with the pinning was removed)

## Does this change affect how this application integrates with other services?

n/a, i think (this strikes me as no different than any other routine dependency update)

~~If so, please confirm:~~
- [ ] ~~change was tested on stage    and/or~~
- [ ] ~~test added to sul-dlss/infrastructure-integration-test~~
