### PR TITLE
Index administrative tags via DOR API

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,6 +36,7 @@ Metrics/ParameterLists:
 # Configuration parameters: Max.
 RSpec/ExampleLength:
   Exclude:
+    - 'spec/indexers/administrative_tag_indexer_spec.rb'
     - 'spec/indexers/composite_indexer_spec.rb'
     - 'spec/indexers/describable_indexer_spec.rb'
     - 'spec/indexers/identifiable_indexer_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'rack-timeout', '~> 0.5.1'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'dor-services', '~> 9.0', '>= 9.2.1' # must be 9.2.1 to get fix from https://github.com/sul-dlss/dor-services/pull/695
-gem 'dor-services-client', '~> 4.11'
+gem 'dor-services-client', '~> 4.20'
 gem 'dor-workflow-client', '~> 3.20'
 gem 'okcomputer' # for monitoring
 gem 'rsolr', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (4.19.0)
+    dor-services-client (4.20.0)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.29)
       deprecation
@@ -152,7 +152,7 @@ GEM
       zeitwerk (~> 2.1)
     druid-tools (2.1.0)
       deprecation
-    dry-configurable (0.11.3)
+    dry-configurable (0.11.4)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
       dry-equalizer (~> 0.2)
@@ -452,7 +452,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano (~> 3.0)
   dor-services (~> 9.0, >= 9.2.1)
-  dor-services-client (~> 4.11)
+  dor-services-client (~> 4.20)
   dor-workflow-client (~> 3.20)
   erubis
   faraday

--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Index administrative tags for an object.
+# NOTE: Most of this code was extracted from the dor-services gem:
+#       https://github.com/sul-dlss/dor-services/blob/v9.0.0/lib/dor/datastreams/identity_metadata_ds.rb#L196-L218
+class AdministrativeTagIndexer
+  TAG_PART_DELIMITER = ' : '
+
+  attr_reader :resource
+
+  def initialize(resource:)
+    @resource = resource
+  end
+
+  # @return [Hash] the partial solr document for administrative tags
+  def to_solr
+    solr_doc = {}
+    administrative_tags.each do |tag|
+      (solr_doc['tag_ssim'] ||= []) << tag
+      solr_doc['exploded_tag_ssim'] ||= []
+      solr_doc['exploded_tag_ssim'] += exploded_tags_from(tag)
+
+      # this part will index a value in a field specific to the tag, e.g. registered_by_tag_*,
+      # book_tag_*, project_tag_*, remediated_by_tag_*, etc.  project_tag_* and registered_by_tag_*
+      # definitely get used, but most don't. we can limit the prefixes that get solrized if things
+      # get out of hand.
+      prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
+      prefix = prefix.downcase.strip.gsub(/\s/, '_')
+      next if rest.nil?
+
+      (solr_doc["#{prefix}_tag_ssim"] ||= []) << rest.strip
+    end
+    solr_doc
+  end
+
+  private
+
+  # solrize each possible prefix for the tag, inclusive of the full tag.
+  # e.g., for a tag such as "A : B : C", this will solrize to an _ssim field
+  # that contains ["A",  "A : B",  "A : B : C"].
+  def exploded_tags_from(tag)
+    tag_parts = tag.split(TAG_PART_DELIMITER)
+
+    1.upto(tag_parts.count).map do |i|
+      tag_parts.take(i).join(TAG_PART_DELIMITER)
+    end
+  end
+
+  def administrative_tags
+    Dor::Services::Client.object(resource.pid).administrative_tags.list
+  rescue Dor::Services::Client::NotFoundResponse
+    []
+  end
+end

--- a/app/indexers/identifiable_indexer.rb
+++ b/app/indexers/identifiable_indexer.rb
@@ -63,6 +63,12 @@ class IdentifiableIndexer
 
   private
 
+  def related_object_tags(object)
+    return [] unless object
+
+    Dor::Services::Client.object(object.pid).administrative_tags.list
+  end
+
   def solrize_related_obj_titles(solr_doc, relationships, title_hash, union_field_name, nonhydrus_field_name, hydrus_field_name)
     # TODO: if you wanted to get a little fancier, you could also solrize a 2 level hierarchy and display using hierarchial facets, like
     # ["SOURCE", "SOURCE : TITLE"] (e.g. ["Hydrus", "Hydrus : Special Collections"], see (exploded) tags in IdentityMetadataDS#to_solr).
@@ -79,7 +85,7 @@ class IdentifiableIndexer
         begin
           related_obj = Dor.find(rel_druid)
           related_obj_title = related_obj_display_title(related_obj, rel_druid)
-          is_from_hydrus = (related_obj&.tags&.include?('Project : Hydrus'))
+          is_from_hydrus = related_object_tags(related_obj).include?('Project : Hydrus')
           title_hash[rel_druid] = { 'related_obj_title' => related_obj_title, 'is_from_hydrus' => is_from_hydrus }
         rescue ActiveFedora::ObjectNotFoundError
           # This may happen if the given APO or Collection does not exist (bad data)

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -2,6 +2,7 @@
 
 class Indexer
   ADMIN_POLICY_INDEXER = CompositeIndexer.new(
+    AdministrativeTagIndexer,
     DataIndexer,
     RoleMetadataDatastreamIndexer,
     AdministrativeMetadataDatastreamIndexer,
@@ -21,6 +22,7 @@ class Indexer
   )
 
   COLLECTION_INDEXER = CompositeIndexer.new(
+    AdministrativeTagIndexer,
     DataIndexer,
     ProvenanceMetadataDatastreamIndexer,
     RightsMetadataDatastreamIndexer,
@@ -37,6 +39,7 @@ class Indexer
   )
 
   ITEM_INDEXER = CompositeIndexer.new(
+    AdministrativeTagIndexer,
     DataIndexer,
     ProvenanceMetadataDatastreamIndexer,
     RightsMetadataDatastreamIndexer,
@@ -55,6 +58,7 @@ class Indexer
   )
 
   SET_INDEXER = CompositeIndexer.new(
+    AdministrativeTagIndexer,
     DataIndexer,
     ProvenanceMetadataDatastreamIndexer,
     RightsMetadataDatastreamIndexer,

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdministrativeTagIndexer do
+  describe '#to_solr' do
+    subject(:document) { indexer.to_solr }
+
+    let(:indexer) { described_class.new(resource: object) }
+    let(:object) { Dor::Abstract.new(pid: 'druid:rt923jk234') }
+    let(:tags) do
+      [
+        'Google Books : Phase 1',
+        'Google Books : Scan source STANFORD',
+        'Project : Beautiful Books',
+        'Registered By : blalbrit',
+        'DPG : Beautiful Books : Octavo : newpri',
+        'Remediated By : 4.15.4'
+      ]
+    end
+
+    before do
+      # Don't actually hit the dor-services-app API endpoint
+      allow(indexer).to receive(:administrative_tags).and_return(tags)
+    end
+
+    it 'indexes all administrative tags' do
+      expect(document).to include('tag_ssim' => tags)
+    end
+
+    it 'indexes exploded tags' do
+      expect(document['exploded_tag_ssim']).to match_array(
+        [
+          'Google Books',
+          'Google Books : Phase 1',
+          'Google Books',
+          'Google Books : Scan source STANFORD',
+          'Project',
+          'Project : Beautiful Books',
+          'Registered By',
+          'Registered By : blalbrit',
+          'DPG',
+          'DPG : Beautiful Books',
+          'DPG : Beautiful Books : Octavo',
+          'DPG : Beautiful Books : Octavo : newpri',
+          'Remediated By',
+          'Remediated By : 4.15.4'
+        ]
+      )
+    end
+
+    it 'indexes prefixed tags' do
+      expect(document).to include(
+        'google_books_tag_ssim' => ['Phase 1', 'Scan source STANFORD'],
+        'project_tag_ssim' => ['Beautiful Books'],
+        'registered_by_tag_ssim' => ['blalbrit'],
+        'dpg_tag_ssim' => ['Beautiful Books : Octavo : newpri'],
+        'remediated_by_tag_ssim' => ['4.15.4']
+      )
+    end
+  end
+end

--- a/spec/indexers/identity_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_datastream_indexer_spec.rb
@@ -47,23 +47,12 @@ RSpec.describe IdentityMetadataDatastreamIndexer do
         'catkey_id_ssim' => ['129483625'],
         'dor_id_tesim' => %w[STANFORD_342837261527 36105049267078 129483625
                              7f3da130-7b02-11de-8a39-0800200c9a66],
-        'exploded_tag_ssim' => ['Google Books', 'Google Books : Phase 1', 'Google Books',
-                                'Google Books : Scan source STANFORD', 'Project', 'Project : Beautiful Books',
-                                'Registered By', 'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books',
-                                'DPG : Beautiful Books : Octavo', 'DPG : Beautiful Books : Octavo : newpri',
-                                'Remediated By', 'Remediated By : 4.15.4'],
         'identifier_ssim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                               'catkey:129483625', 'uuid:7f3da130-7b02-11de-8a39-0800200c9a66'],
         'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                                'catkey:129483625', 'uuid:7f3da130-7b02-11de-8a39-0800200c9a66'],
         'objectType_ssim' => ['item'],
-        'project_tag_ssim' => ['Beautiful Books'],
-        'registered_by_tag_ssim' => ['blalbrit'],
-        'source_id_ssim' => ['google:STANFORD_342837261527'],
-        'tag_ssim' => ['Google Books : Phase 1', 'Google Books : Scan source STANFORD',
-                       'Project : Beautiful Books', 'Registered By : blalbrit',
-                       'DPG : Beautiful Books : Octavo : newpri',
-                       'Remediated By : 4.15.4']
+        'source_id_ssim' => ['google:STANFORD_342837261527']
       )
     end
   end

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -5,6 +5,26 @@ require 'rails_helper'
 RSpec.describe Indexer do
   subject(:indexer) { described_class.for(model) }
 
+  let(:processable) do
+    instance_double(ProcessableIndexer, to_solr: { 'milestones_ssim' => %w[foo bar] })
+  end
+  let(:releasable) do
+    instance_double(ReleasableIndexer, to_solr: { 'released_to_ssim' => %w[searchworks earthworks] })
+  end
+  let(:workflows) do
+    instance_double(WorkflowsIndexer, to_solr: { 'wf_ssim' => ['accessionWF'] })
+  end
+  let(:admin_tags) do
+    instance_double(AdministrativeTagIndexer, to_solr: { 'tag_ssim' => ['Test : Tag'] })
+  end
+
+  before do
+    allow(ProcessableIndexer).to receive(:new).and_return(processable)
+    allow(ReleasableIndexer).to receive(:new).and_return(releasable)
+    allow(WorkflowsIndexer).to receive(:new).and_return(workflows)
+    allow(AdministrativeTagIndexer).to receive(:new).and_return(admin_tags)
+  end
+
   context 'when the model is an item' do
     let(:model) { Dor::Item.new(pid: 'druid:xx999xx9999') }
 
@@ -13,23 +33,7 @@ RSpec.describe Indexer do
     describe '#to_solr' do
       subject { indexer.to_solr }
 
-      let(:processable) do
-        instance_double(ProcessableIndexer, to_solr: { 'milestones_ssim' => %w[foo bar] })
-      end
-      let(:releasable) do
-        instance_double(ReleasableIndexer, to_solr: { 'released_to_ssim' => %w[searchworks earthworks] })
-      end
-      let(:workflows) do
-        instance_double(WorkflowsIndexer, to_solr: { 'wf_ssim' => ['accessionWF'] })
-      end
-
-      before do
-        allow(ProcessableIndexer).to receive(:new).and_return(processable)
-        allow(ReleasableIndexer).to receive(:new).and_return(releasable)
-        allow(WorkflowsIndexer).to receive(:new).and_return(workflows)
-      end
-
-      it { is_expected.to include('milestones_ssim', 'released_to_ssim', 'wf_ssim') }
+      it { is_expected.to include('milestones_ssim', 'released_to_ssim', 'wf_ssim', 'tag_ssim') }
     end
   end
 
@@ -41,19 +45,7 @@ RSpec.describe Indexer do
     describe '#to_solr' do
       subject { indexer.to_solr }
 
-      let(:processable) do
-        instance_double(ProcessableIndexer, to_solr: { 'milestones_ssim' => %w[foo bar] })
-      end
-      let(:workflows) do
-        instance_double(WorkflowsIndexer, to_solr: { 'wf_ssim' => ['accessionWF'] })
-      end
-
-      before do
-        allow(ProcessableIndexer).to receive(:new).and_return(processable)
-        allow(WorkflowsIndexer).to receive(:new).and_return(workflows)
-      end
-
-      it { is_expected.to include('milestones_ssim', 'wf_ssim') }
+      it { is_expected.to include('milestones_ssim', 'wf_ssim', 'tag_ssim') }
     end
   end
 
@@ -71,19 +63,7 @@ RSpec.describe Indexer do
     describe '#to_solr' do
       subject { indexer.to_solr }
 
-      let(:processable) do
-        instance_double(ProcessableIndexer, to_solr: { 'milestones_ssim' => %w[foo bar] })
-      end
-      let(:workflows) do
-        instance_double(WorkflowsIndexer, to_solr: { 'wf_ssim' => ['accessionWF'] })
-      end
-
-      before do
-        allow(ProcessableIndexer).to receive(:new).and_return(processable)
-        allow(WorkflowsIndexer).to receive(:new).and_return(workflows)
-      end
-
-      it { is_expected.to include('milestones_ssim', 'wf_ssim') }
+      it { is_expected.to include('milestones_ssim', 'wf_ssim', 'tag_ssim') }
     end
   end
 


### PR DESCRIPTION
Unblocks sul-dlss/dor-services-app#709
Part of sul-dlss/dor-services-app#679

As part of this work, stop indexing tags via the identity metadata datastream.

## Why was this change made?

To make sure tags added to objects via API are indexed.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

No.

## Does this change affect how this application integrates with other services?

Yes, and it was tested successfully in stage and now there's an integration test: https://github.com/sul-dlss/infrastructure-integration-test/pull/34