### PR TITLE
Registered ETDs should index their title

### DIFF
--- a/app/indexers/etd_properties_datastream_indexer.rb
+++ b/app/indexers/etd_properties_datastream_indexer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class EtdPropertiesDatastreamIndexer
+  attr_reader :resource
+  def initialize(resource:)
+    @resource = resource
+  end
+
+  # @return [Hash] the partial solr document for the properties
+  def to_solr
+    # Namely this does `title_tesim`
+    resource.properties.to_solr
+  end
+end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -36,6 +36,7 @@ class Indexer
 
   ETD_INDEXER = CompositeIndexer.new(
     DataIndexer,
+    EtdPropertiesDatastreamIndexer,
     ProvenanceMetadataDatastreamIndexer,
     RightsMetadataDatastreamIndexer,
     EventsDatastreamIndexer,

--- a/spec/indexers/etd_properties_datastream_indexer_spec.rb
+++ b/spec/indexers/etd_properties_datastream_indexer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EtdPropertiesDatastreamIndexer do
+  let(:obj) do
+    Dor::Etd.new.tap do |obj|
+      obj.properties.title = 'hello'
+    end
+  end
+
+  let(:indexer) do
+    described_class.new(resource: obj)
+  end
+
+  describe '#to_solr' do
+    let(:indexer) do
+      CompositeIndexer.new(
+        described_class
+      ).new(resource: obj)
+    end
+    let(:doc) { indexer.to_solr }
+
+    it 'makes a solr doc' do
+      expect(doc).to match a_hash_including('title_tesim' => 'hello')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Unaccessioned ETD titles were not displaying in Argo.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a


## Does this change affect how this application integrates with other services?
n/a
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
