### PR TITLE
Cast etds to etd class

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -43,6 +43,10 @@ class DorController < ApplicationController
     # benchmark how long it takes to load the object
     load_stats = Benchmark.measure('load_instance') do
       obj = Dor.find pid
+      # Etds are not mapping to Etd by default (see adapt_to_cmodel in Dor::Abstract)
+      # This hack overrides that behavior and ensures Etds can be indexed.
+      models = ActiveFedora::ContentModel.models_asserted_by(obj)
+      obj = obj.adapt_to(Etd) if models.include?('info:fedora/afmodel:Etd')
     end.format('%n realtime %rs total CPU %ts').gsub(/[\(\)]/, '')
 
     # benchmark how long it takes to convert the object to a Solr document

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This is necessary, so that Dor.find will cast etds to this type.
+# Otherwise it'll say: Etd is not a real class
+# and return a Dor::Item.
+# This is necessary for the Cocina::Mapper because Etds do not use descMetadata
+# like ever other object.
+class Etd < Dor::Etd
+  # This is required so that LegacyMetadataService can write contentMetadata.
+  # We need it because Dor::Etd's parent is Dor::Abstract rather than Dor::Item
+  # The other-metadata robot in the etdSubmitWF calls the legacy metadata update.
+  has_metadata name: 'contentMetadata',
+               type: Dor::ContentMetadataDS,
+               label: 'Content Metadata',
+               control_group: 'M'
+end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -82,7 +82,7 @@ class Indexer
     Dor::Agreement => ITEM_INDEXER, # Agreement uses same indexer as Dor::Item
     Dor::AdminPolicyObject => ADMIN_POLICY_INDEXER,
     Dor::Collection => COLLECTION_INDEXER,
-    Dor::Etd => ETD_INDEXER,
+    Etd => ETD_INDEXER,
     Hydrus::Item => ITEM_INDEXER,
     Hydrus::AdminPolicyObject => ADMIN_POLICY_INDEXER,
     Dor::Item => ITEM_INDEXER,

--- a/spec/indexers/etd_properties_datastream_indexer_spec.rb
+++ b/spec/indexers/etd_properties_datastream_indexer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe EtdPropertiesDatastreamIndexer do
   let(:obj) do
-    Dor::Etd.new.tap do |obj|
+    Etd.new.tap do |obj|
       obj.properties.title = 'hello'
     end
   end


### PR DESCRIPTION
## Why was this change made?

Etds were being loaded as Dor::Item and thus not getting the correct indexing chain.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

n/a

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
