### PR TITLE
[HOLD] Pass the cocina instance to each indexer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,6 @@ Metrics/MethodLength:
 
 Naming/PredicateName:
   NamePrefixBlacklist: is_
+
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true

--- a/app/indexers/administrative_metadata_datastream_indexer.rb
+++ b/app/indexers/administrative_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class AdministrativeMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/composite_indexer.rb
+++ b/app/indexers/composite_indexer.rb
@@ -7,15 +7,15 @@ class CompositeIndexer
     @indexers = indexers
   end
 
-  def new(resource:)
-    Instance.new(indexers, resource: resource)
+  def new(resource:, cocina:)
+    Instance.new(indexers, resource: resource, cocina: cocina)
   end
 
   class Instance
     attr_reader :indexers, :resource
-    def initialize(indexers, resource:)
+    def initialize(indexers, resource:, cocina:)
       @resource = resource
-      @indexers = indexers.map { |i| i.new(resource: resource) }
+      @indexers = indexers.map { |i| i.new(resource: resource, cocina: cocina) }
     end
 
     # @return [Hash] the merged solr document for all the sub-indexers

--- a/app/indexers/content_metadata_datastream_indexer.rb
+++ b/app/indexers/content_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class ContentMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/data_indexer.rb
+++ b/app/indexers/data_indexer.rb
@@ -5,7 +5,7 @@ class DataIndexer
   include ActiveFedora::Indexing
 
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/default_object_rights_datastream_indexer.rb
+++ b/app/indexers/default_object_rights_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class DefaultObjectRightsDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/describable_indexer.rb
+++ b/app/indexers/describable_indexer.rb
@@ -2,7 +2,7 @@
 
 class DescribableIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/descriptive_metadata_datastream_indexer.rb
+++ b/app/indexers/descriptive_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class DescriptiveMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/editable_indexer.rb
+++ b/app/indexers/editable_indexer.rb
@@ -4,7 +4,7 @@ class EditableIndexer
   include SolrDocHelper
 
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/embargo_metadata_datastream_indexer.rb
+++ b/app/indexers/embargo_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class EmbargoMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/etd_properties_datastream_indexer.rb
+++ b/app/indexers/etd_properties_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class EtdPropertiesDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/events_datastream_indexer.rb
+++ b/app/indexers/events_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class EventsDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/identifiable_indexer.rb
+++ b/app/indexers/identifiable_indexer.rb
@@ -9,7 +9,7 @@ class IdentifiableIndexer
               'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' }.freeze
 
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/identity_metadata_datastream_indexer.rb
+++ b/app/indexers/identity_metadata_datastream_indexer.rb
@@ -4,7 +4,7 @@ class IdentityMetadataDatastreamIndexer
   include SolrDocHelper
 
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/object_profile_indexer.rb
+++ b/app/indexers/object_profile_indexer.rb
@@ -5,7 +5,7 @@ class ObjectProfileIndexer
 
   attr_reader :resource
 
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/processable_indexer.rb
+++ b/app/indexers/processable_indexer.rb
@@ -4,7 +4,7 @@ class ProcessableIndexer
   include SolrDocHelper
 
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/provenance_metadata_datastream_indexer.rb
+++ b/app/indexers/provenance_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class ProvenanceMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/releasable_indexer.rb
+++ b/app/indexers/releasable_indexer.rb
@@ -5,7 +5,7 @@ class ReleasableIndexer
 
   attr_reader :resource
 
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/rights_metadata_datastream_indexer.rb
+++ b/app/indexers/rights_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class RightsMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/role_metadata_datastream_indexer.rb
+++ b/app/indexers/role_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class RoleMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/version_metadata_datastream_indexer.rb
+++ b/app/indexers/version_metadata_datastream_indexer.rb
@@ -2,7 +2,7 @@
 
 class VersionMetadataDatastreamIndexer
   attr_reader :resource
-  def initialize(resource:)
+  def initialize(resource:, cocina:)
     @resource = resource
   end
 

--- a/app/indexers/workflows_indexer.rb
+++ b/app/indexers/workflows_indexer.rb
@@ -2,9 +2,9 @@
 
 # Indexes the objects position in workflows
 class WorkflowsIndexer
-  attr_reader :resource
-  def initialize(resource:)
-    @resource = resource
+  attr_reader :cocina
+  def initialize(resource:, cocina:)
+    @cocina = cocina
   end
 
   # @return [Hash] the partial solr document for workflow concerns
@@ -27,6 +27,6 @@ class WorkflowsIndexer
   # TODO: remove Dor::Workflow::Document
   # @return [Workflow::Response::Workflows]
   def all_workflows
-    @all_workflows ||= WorkflowClientFactory.build.workflow_routes.all_workflows pid: resource.pid
+    @all_workflows ||= WorkflowClientFactory.build.workflow_routes.all_workflows pid: cocina.externalIdentifier
   end
 end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -94,7 +94,7 @@ class Indexer
     Dor::Set => SET_INDEXER
   }.freeze
 
-  def self.for(obj)
-    INDEXERS.fetch(obj.class).new(resource: obj)
+  def self.for(fedora:, cocina:)
+    INDEXERS.fetch(fedora.class).new(resource: fedora, cocina: cocina)
   end
 end

--- a/spec/controllers/dor_controller_spec.rb
+++ b/spec/controllers/dor_controller_spec.rb
@@ -8,9 +8,13 @@ RSpec.describe DorController, type: :controller do
       expect(Logger).to receive(:new).and_return(mock_logger)
       allow(ActiveFedora.solr).to receive(:conn).and_return(mock_solr_conn)
       allow(Dor).to receive(:find).with(mock_druid).and_return(mock_af_doc)
-      allow(Indexer).to receive(:for).with(mock_af_doc).and_return(mock_indexer)
+      allow(Dor::Services::Client).to receive(:object).with(mock_druid).and_return(object_client)
+
+      allow(Indexer).to receive(:for).with(fedora: mock_af_doc, cocina: cocina_model).and_return(mock_indexer)
     end
 
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: cocina_model) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO) }
     let(:mock_logger) { instance_double(Logger, :formatter= => true, info: true) }
     let(:mock_solr_conn) { instance_double(RSolr::Client, add: true, commit: true) }
     let(:mock_af_doc) { Dor::Item.new }

--- a/spec/indexers/composite_indexer_spec.rb
+++ b/spec/indexers/composite_indexer_spec.rb
@@ -46,13 +46,14 @@ RSpec.describe CompositeIndexer do
       ProcessableIndexer
     )
   end
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   describe 'to_solr' do
     let(:status) do
       instance_double(Dor::Workflow::Client::Status, milestones: {}, info: {}, display: 'bad')
     end
     let(:workflow_client) { instance_double(Dor::Workflow::Client, status: status) }
-    let(:doc) { indexer.new(resource: obj).to_solr }
+    let(:doc) { indexer.new(resource: obj, cocina: cocina).to_solr }
 
     before do
       allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)

--- a/spec/indexers/data_indexer_spec.rb
+++ b/spec/indexers/data_indexer_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe DataIndexer do
   end
 
   let(:indexer) do
-    described_class.new(resource: obj)
+    described_class.new(resource: obj, cocina: cocina)
   end
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   describe '#to_solr' do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj)
+      ).new(resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/default_object_rights_datastream_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_datastream_indexer_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe DefaultObjectRightsDatastreamIndexer do
   end
 
   let(:indexer) do
-    described_class.new(resource: obj)
+    described_class.new(resource: obj, cocina: cocina)
   end
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   describe '#to_solr' do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj)
+      ).new(resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/describable_indexer_spec.rb
+++ b/spec/indexers/describable_indexer_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe DescribableIndexer do
+  subject(:indexer) { described_class.new(resource: obj, cocina: cocina) }
+
   let(:xml) do
     <<~XML
       <?xml version="1.0" encoding="UTF-8"?>
@@ -90,9 +92,7 @@ RSpec.describe DescribableIndexer do
   end
   let(:obj) { Dor::Abstract.new }
 
-  let(:indexer) do
-    described_class.new(resource: obj)
-  end
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   describe '#to_solr' do
     let(:doc) { indexer.to_solr }

--- a/spec/indexers/editable_indexer_spec.rb
+++ b/spec/indexers/editable_indexer_spec.rb
@@ -3,14 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe EditableIndexer do
+  subject(:indexer) do
+    described_class.new(resource: obj, cocina: cocina)
+  end
+
   let(:obj) do
     instance_double(Dor::AdminPolicyObject,
                     default_rights: 'world',
                     use_license: 'by-nc-sa')
   end
-  let(:indexer) do
-    described_class.new(resource: obj)
-  end
+
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   describe '#default_rights_for_indexing' do
     it 'uses the OM template if the ds is empty' do
@@ -22,7 +25,7 @@ RSpec.describe EditableIndexer do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj)
+      ).new(resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/etd_properties_datastream_indexer_spec.rb
+++ b/spec/indexers/etd_properties_datastream_indexer_spec.rb
@@ -8,16 +8,17 @@ RSpec.describe EtdPropertiesDatastreamIndexer do
       obj.properties.title = 'hello'
     end
   end
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   let(:indexer) do
-    described_class.new(resource: obj)
+    described_class.new(resource: obj, cocina: cocina)
   end
 
   describe '#to_solr' do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj)
+      ).new(resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/identifiable_indexer_spec.rb
+++ b/spec/indexers/identifiable_indexer_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe IdentifiableIndexer do
   let(:obj) { Dor::Abstract.new(pid: 'druid:rt923jk342') }
 
   let(:indexer) do
-    described_class.new(resource: obj)
+    described_class.new(resource: obj, cocina: cocina)
   end
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   before do
     obj.identityMetadata.content = xml

--- a/spec/indexers/identity_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_datastream_indexer_spec.rb
@@ -29,9 +29,10 @@ RSpec.describe IdentityMetadataDatastreamIndexer do
   end
 
   let(:obj) { Dor::Item.new(pid: 'druid:rt923jk342') }
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   let(:indexer) do
-    described_class.new(resource: obj)
+    described_class.new(resource: obj, cocina: cocina)
   end
 
   before do

--- a/spec/indexers/object_profile_indexer_spec.rb
+++ b/spec/indexers/object_profile_indexer_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe ObjectProfileIndexer do
   let(:obj) do
     Dor::Item.new
   end
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   let(:indexer) do
-    described_class.new(resource: obj)
+    described_class.new(resource: obj, cocina: cocina)
   end
 
   let(:rubydora_obj) do
@@ -27,7 +28,7 @@ RSpec.describe ObjectProfileIndexer do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj)
+      ).new(resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/processable_indexer_spec.rb
+++ b/spec/indexers/processable_indexer_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ProcessableIndexer do
-  let(:indexer) { described_class.new(resource: obj) }
+  let(:indexer) { described_class.new(resource: obj, cocina: cocina) }
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   describe '#to_solr' do
     let(:obj) do
@@ -32,7 +33,7 @@ RSpec.describe ProcessableIndexer do
         let(:indexer) do
           CompositeIndexer.new(
             described_class
-          ).new(resource: obj)
+          ).new(resource: obj, cocina: cocina)
         end
 
         let(:status) do

--- a/spec/indexers/releasable_indexer_spec.rb
+++ b/spec/indexers/releasable_indexer_spec.rb
@@ -4,9 +4,10 @@ require 'rails_helper'
 
 RSpec.describe ReleasableIndexer do
   let(:obj) { instance_double(Dor::Abstract, pid: 'druid:pz263ny9658') }
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   describe 'to_solr' do
-    let(:doc) { described_class.new(resource: obj).to_solr }
+    let(:doc) { described_class.new(resource: obj, cocina: cocina).to_solr }
     let(:released_for_info) do
       {
         'Project' => { 'release' => true },

--- a/spec/indexers/rights_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/rights_metadata_datastream_indexer_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe RightsMetadataDatastreamIndexer do
   end
 
   let(:obj) { Dor::Item.new(pid: 'druid:rt923jk342') }
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   let(:indexer) do
-    described_class.new(resource: obj)
+    described_class.new(resource: obj, cocina: cocina)
   end
 
   before do

--- a/spec/indexers/workflows_indexer_spec.rb
+++ b/spec/indexers/workflows_indexer_spec.rb
@@ -3,9 +3,12 @@
 require 'spec_helper'
 
 RSpec.describe WorkflowsIndexer do
-  let(:obj) { instance_double(Dor::Item, pid: 'druid:ab123cd4567') }
+  subject(:indexer) { described_class.new(resource: obj, cocina: cocina) }
 
-  let(:indexer) { described_class.new(resource: obj) }
+  let(:pid) { 'druid:ab123cd4567' }
+  let(:obj) { instance_double(Dor::Item) }
+  let(:cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: pid) }
+  # let(:cocina) { Cocina::Models::DRO.new(externalId: pid) }
 
   describe '#to_solr' do
     let(:solr_doc) { indexer.to_solr }

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Indexer do
-  subject(:indexer) { described_class.for(model) }
+  subject(:indexer) { described_class.for(fedora: fedora, cocina: cocina) }
+
+  let(:cocina) { instance_double(Cocina::Models::DRO) }
 
   context 'when the model is an item' do
-    let(:model) { Dor::Item.new(pid: 'druid:xx999xx9999') }
+    let(:fedora) { Dor::Item.new(pid: 'druid:xx999xx9999') }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
 
@@ -34,7 +36,7 @@ RSpec.describe Indexer do
   end
 
   context 'when the model is an admin policy' do
-    let(:model) { Dor::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
+    let(:fedora) { Dor::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
 
@@ -58,13 +60,13 @@ RSpec.describe Indexer do
   end
 
   context 'when the model is a hydrus item' do
-    let(:model) { Hydrus::Item.new }
+    let(:fedora) { Hydrus::Item.new }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is a hydrus apo' do
-    let(:model) { Hydrus::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
+    let(:fedora) { Hydrus::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
 
@@ -88,13 +90,13 @@ RSpec.describe Indexer do
   end
 
   context 'when the model is a collection' do
-    let(:model) { Dor::Collection.new }
+    let(:fedora) { Dor::Collection.new }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is an agreement' do
-    let(:model) { Dor::Agreement.new }
+    let(:fedora) { Dor::Agreement.new }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end


### PR DESCRIPTION
*Note* This requires that every object has a sourceId (or dor-services-app can't create a Cocina model).  Currently not everything has one.  All data needs to be remediated before this can go forward.


## Why was this change made?
This makes it possible to migrate each indexer to use the cocina model


## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?
n/a


## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
