### PR TITLE
Bump DSC for compatibility with latest cocina models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'rack-timeout', '~> 0.5.1'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'dor-services', '~> 9.0', '>= 9.2.1' # must be 9.2.1 to get fix from https://github.com/sul-dlss/dor-services/pull/695
-gem 'dor-services-client', '~> 4.20'
+gem 'dor-services-client', '~> 5.0'
 gem 'dor-workflow-client', '~> 3.20'
 gem 'okcomputer' # for monitoring
 gem 'rsolr', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    cocina-models (0.32.0)
+    cocina-models (0.31.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -142,9 +142,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (4.20.0)
+    dor-services-client (5.1.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.29)
+      cocina-models (~> 0.31.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -466,7 +466,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano (~> 3.0)
   dor-services (~> 9.0, >= 9.2.1)
-  dor-services-client (~> 4.20)
+  dor-services-client (~> 5.0)
   dor-workflow-client (~> 3.20)
   erubis
   faraday


### PR DESCRIPTION
## Why was this change made?

To better keep pace with cocina models changes and not break DSC.



## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?

Should prevent DSA integration breakage