### PR TITLE
Move embargo metadata indexing locally

### DIFF
--- a/app/indexers/embargo_metadata_datastream_indexer.rb
+++ b/app/indexers/embargo_metadata_datastream_indexer.rb
@@ -8,6 +8,21 @@ class EmbargoMetadataDatastreamIndexer
 
   # @return [Hash] the partial solr document for embargoMetadata
   def to_solr
-    resource.embargoMetadata.to_solr
+    {
+      'embargo_status_ssim' => embargo_status,
+      'twenty_pct_status_ssim' => Array(twenty_pct_status)
+    }.tap do |solr_doc|
+      rd20 = twenty_pct_release_date
+      solr_doc['embargo_release_dtsim'] = Array(release_date.first.utc.strftime('%FT%TZ')) if release_date.first.present?
+      solr_doc['twenty_pct_release_embargo_release_dtsim'] = Array(rd20.utc.strftime('%FT%TZ')) if rd20.present?
+    end
   end
+
+  # rubocop:disable Lint/UselessAccessModifier
+  private
+
+  # rubocop:enable Lint/UselessAccessModifier
+
+  delegate :embargoMetadata, to: :resource
+  delegate :embargo_status, :twenty_pct_status, :twenty_pct_release_date, :release_date, to: :embargoMetadata
 end

--- a/spec/indexers/embargo_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/embargo_metadata_datastream_indexer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmbargoMetadataDatastreamIndexer do
+  let(:xml) do
+    <<~XML
+      <?xml version="1.0"?>
+      <embargoMetadata>
+        <status>embargoed</status>
+        <releaseDate>2011-10-12T15:47:52-07:00</releaseDate>
+        <twentyPctVisibilityStatus>released</twentyPctVisibilityStatus>
+        <twentyPctVisibilityReleaseDate>2016-10-12T15:47:52-07:00</twentyPctVisibilityReleaseDate>
+        <releaseAccess>
+          <access type="discover">
+            <machine>
+              <world />
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world />
+            </machine>
+          </access>
+        </releaseAccess>
+      </embargoMetadata>
+    XML
+  end
+
+  let(:obj) { Dor::Item.new }
+
+  let(:indexer) do
+    described_class.new(resource: obj)
+  end
+
+  before do
+    obj.embargoMetadata.content = xml
+  end
+
+  describe '#to_solr' do
+    subject(:doc) { indexer.to_solr }
+
+    it 'has the fields used by argo' do
+      expect(doc).to eq('embargo_release_dtsim' => ['2011-10-12T22:47:52Z'],
+                        'embargo_status_ssim' => ['embargoed'],
+                        'twenty_pct_status_ssim' => ['released'],
+                        'twenty_pct_release_embargo_release_dtsim' => ['2016-10-12T22:47:52Z'])
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This enables us to move to cocina for doing indexing down the road.

## Was the documentation (README, DevOpsDocs, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no
