### PR TITLE
Remove unused describable fields

### DIFF
--- a/app/indexers/describable_indexer.rb
+++ b/app/indexers/describable_indexer.rb
@@ -20,16 +20,14 @@ class DescribableIndexer
     mods_sources = {
       sw_title_display: %w[sw_display_title_tesim],
       main_author_w_date: %w[sw_author_ssim sw_author_tesim],
-      sw_sort_author: %w[sw_author_sort_ssi],
-      sw_language_facet: %w[sw_language_ssim sw_language_tesim],
-      sw_genre: %w[sw_genre_ssim sw_genre_tesim],
-      format_main: %w[sw_format_ssim sw_format_tesim],
-      topic_facet: %w[sw_topic_ssim sw_topic_tesim],
-      era_facet: %w[sw_subject_temporal_ssim sw_subject_temporal_tesim],
-      geographic_facet: %w[sw_subject_geographic_ssim sw_subject_geographic_tesim],
-      %i[term_values typeOfResource] => %w[mods_typeOfResource_ssim mods_typeOfResource_tesim],
+      sw_language_facet: %w[sw_language_ssim],
+      sw_genre: %w[sw_genre_ssim],
+      format_main: %w[sw_format_ssim],
+      topic_facet: %w[sw_topic_ssim],
+      era_facet: %w[sw_subject_temporal_ssim],
+      geographic_facet: %w[sw_subject_geographic_ssim],
+      %i[term_values typeOfResource] => %w[mods_typeOfResource_ssim],
       pub_year_sort_str: %w[sw_pub_date_sort_ssi],
-      pub_year_int: %w[sw_pub_date_sort_isi],
       pub_year_display_str: %w[sw_pub_date_facet_ssi]
     }
 
@@ -46,12 +44,8 @@ class DescribableIndexer
     end
 
     # convert multivalued fields to single value
-    %w[sw_pub_date_sort_ssi sw_pub_date_sort_isi sw_pub_date_facet_ssi].each do |key|
+    %w[sw_pub_date_sort_ssi sw_pub_date_facet_ssi].each do |key|
       solr_doc[key] = solr_doc[key].first unless solr_doc[key].nil?
-    end
-    # some fields get explicit "(none)" placeholder values, mostly for faceting
-    %w[sw_language_tesim sw_genre_tesim sw_format_tesim].each do |key|
-      solr_doc[key] = ['(none)'] if solr_doc[key].blank?
     end
     solr_doc
   end

--- a/spec/indexers/composite_indexer_spec.rb
+++ b/spec/indexers/composite_indexer_spec.rb
@@ -61,25 +61,21 @@ RSpec.describe CompositeIndexer do
     it 'searchworks date-fu: temporal periods and pub_dates' do
       expect(doc).to match a_hash_including(
         'sw_subject_temporal_ssim' => a_collection_containing_exactly('18th century', '17th century'),
-        'sw_subject_temporal_tesim' => a_collection_containing_exactly('18th century', '17th century'),
         'sw_pub_date_sort_ssi' => '1600',
-        'sw_pub_date_sort_isi' => 1600,
         'sw_pub_date_facet_ssi' => '1600'
       )
     end
 
     it 'subject geographic fields' do
       expect(doc).to match a_hash_including(
-        'sw_subject_geographic_ssim' => %w[Europe Europe],
-        'sw_subject_geographic_tesim' => %w[Europe Europe]
+        'sw_subject_geographic_ssim' => %w[Europe Europe]
       )
     end
 
     it 'genre fields' do
       genre_list = obj.stanford_mods.sw_genre
       expect(doc).to match a_hash_including(
-        'sw_genre_ssim' => genre_list,
-        'sw_genre_tesim' => genre_list
+        'sw_genre_ssim' => genre_list
       )
     end
   end

--- a/spec/indexers/describable_indexer_spec.rb
+++ b/spec/indexers/describable_indexer_spec.rb
@@ -104,13 +104,9 @@ RSpec.describe DescribableIndexer do
     it 'includes values from stanford_mods' do
       expect(doc).to match a_hash_including(
         'sw_language_ssim' => ['English'],
-        'sw_language_tesim' => ['English'],
         'sw_format_ssim' => ['Book'],
-        'sw_format_tesim' => ['Book'],
         'sw_subject_temporal_ssim' => ['1800-1900'],
-        'sw_subject_temporal_tesim' => ['1800-1900'],
         'sw_pub_date_sort_ssi' => '1911',
-        'sw_pub_date_sort_isi' => 1911,
         'sw_pub_date_facet_ssi' => '1911'
       )
     end


### PR DESCRIPTION
## Why was this change made?

These fields were not being used, so stop indexing them to make the index smaller.

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

