### PR TITLE
ObjectProfileIndexer only needs to index obj_label

### DIFF
--- a/app/indexers/object_profile_indexer.rb
+++ b/app/indexers/object_profile_indexer.rb
@@ -11,19 +11,8 @@ class ObjectProfileIndexer
 
   # @return [Hash] the partial solr document for releasable concerns
   def to_solr
-    return {} unless inner_object.respond_to?(:profile) # Skip unsaved items
-
     {}.tap do |solr_doc|
-      inner_object.profile.each_pair do |property, value|
-        add_solr_value(solr_doc, property.underscore, value, (property.match?(/Date/) ? :date : :symbol), [:stored_searchable])
-      end
+      add_solr_value(solr_doc, 'obj_label', resource.label, :symbol, [:stored_searchable])
     end
   end
-
-  # rubocop:disable Lint/UselessAccessModifier
-  private
-
-  # rubocop:enable Lint/UselessAccessModifier
-
-  delegate :inner_object, to: :resource
 end

--- a/spec/indexers/object_profile_indexer_spec.rb
+++ b/spec/indexers/object_profile_indexer_spec.rb
@@ -4,23 +4,11 @@ require 'rails_helper'
 
 RSpec.describe ObjectProfileIndexer do
   let(:obj) do
-    Dor::Item.new
+    Dor::Item.new(label: 'test label')
   end
 
   let(:indexer) do
     described_class.new(resource: obj)
-  end
-
-  let(:rubydora_obj) do
-    instance_double(Rubydora::DigitalObject, profile: profile)
-  end
-
-  let(:profile) do
-    { 'objLabel' => 'test label' }
-  end
-
-  before do
-    allow(obj).to receive(:inner_object).and_return(rubydora_obj)
   end
 
   describe '#to_solr' do
@@ -32,7 +20,10 @@ RSpec.describe ObjectProfileIndexer do
     let(:doc) { indexer.to_solr }
 
     it 'makes a solr doc' do
-      expect(doc).to match a_hash_including('obj_label_tesim' => ['test label'])
+      expect(doc).to match a_hash_including(
+        'obj_label_tesim' => ['test label'],
+        'obj_label_ssim' => ['test label']
+      )
     end
   end
 end


### PR DESCRIPTION


## Why was this change made?

None of the other fields in the profile are used

## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?
n/a


