### PR TITLE
Only index the tags we use

### DIFF
--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -5,6 +5,7 @@
 #       https://github.com/sul-dlss/dor-services/blob/v9.0.0/lib/dor/datastreams/identity_metadata_ds.rb#L196-L218
 class AdministrativeTagIndexer
   TAG_PART_DELIMITER = ' : '
+  TAGS_TO_INDEX = ['Project', 'Registered By'].freeze
 
   attr_reader :resource
 
@@ -20,14 +21,10 @@ class AdministrativeTagIndexer
       solr_doc['exploded_tag_ssim'] ||= []
       solr_doc['exploded_tag_ssim'] += exploded_tags_from(tag)
 
-      # this part will index a value in a field specific to the tag, e.g. registered_by_tag_*,
-      # book_tag_*, project_tag_*, remediated_by_tag_*, etc.  project_tag_* and registered_by_tag_*
-      # definitely get used, but most don't. we can limit the prefixes that get solrized if things
-      # get out of hand.
-      prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
-      prefix = prefix.downcase.strip.gsub(/\s/, '_')
-      next if rest.nil?
+      tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
+      next if !TAGS_TO_INDEX.include?(tag_prefix) || rest.nil?
 
+      prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
       (solr_doc["#{prefix}_tag_ssim"] ||= []) << rest.strip
     end
     solr_doc

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -51,11 +51,8 @@ RSpec.describe AdministrativeTagIndexer do
 
     it 'indexes prefixed tags' do
       expect(document).to include(
-        'google_books_tag_ssim' => ['Phase 1', 'Scan source STANFORD'],
         'project_tag_ssim' => ['Beautiful Books'],
-        'registered_by_tag_ssim' => ['blalbrit'],
-        'dpg_tag_ssim' => ['Beautiful Books : Octavo : newpri'],
-        'remediated_by_tag_ssim' => ['4.15.4']
+        'registered_by_tag_ssim' => ['blalbrit']
       )
     end
   end


### PR DESCRIPTION
## Why was this change made?
This keeps the index size under control and helps us better understand what data we depend on.


## How was this change tested?

Test suite


## Which documentation and/or configurations were updated?

n/a
