### PR TITLE
Remove ruby 2.5 from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.5.3 # deployed
   - 2.7.1
 
 before_install:


### PR DESCRIPTION


## Why was this change made?

We no longer deploy on ruby 2.5

## How was this change tested?

Travis

## Which documentation and/or configurations were updated?
n/a


