### PR TITLE
Stop indexing ds_spec_ssim

### DIFF
--- a/app/indexers/identifiable_indexer.rb
+++ b/app/indexers/identifiable_indexer.rb
@@ -36,10 +36,6 @@ class IdentifiableIndexer
     solr_doc[INDEX_VERSION_FIELD] = Dor::VERSION
     solr_doc['indexer_host_ssi'] = Socket.gethostname
     solr_doc['indexed_at_dtsi'] = Time.now.utc.xmlschema
-    resource.datastreams.values.each do |ds|
-      # This is used to draw the table of datastreams in Argo
-      add_solr_value(solr_doc, 'ds_specs', ds.datastream_spec_string, :string, [:symbol]) unless ds.new?
-    end
 
     add_solr_value(solr_doc, 'title_sort', resource.label, :string, [:stored_sortable])
 


### PR DESCRIPTION


## Why was this change made?
This is no longer used as of https://github.com/sul-dlss/argo/pull/2103 and it was causing significant slowness of the indexing process, especially when on external datastreams. This example takes over 20s:
```ruby
druid = 'druid:fw763ds3827'
resource = Dor.find(druid)
resource.datastreams['workflows'].datastream_spec_string
```


## How was this change tested?

test suite



## Which documentation and/or configurations were updated?

n/a

