### PR TITLE
Index CDL objects correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'rack-timeout', '~> 0.5.1'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'dor-rights-auth', '~>1.5' # 1.5 or better is needed to ensure we index controlled digital lending rights object correctly
 gem 'dor-services', '~> 9.0', '>= 9.2.1' # must be 9.2.1 to get fix from https://github.com/sul-dlss/dor-services/pull/695
 gem 'dor-services-client', '~> 6.0'
 gem 'dor-workflow-client', '~> 3.20'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dor-rights-auth (1.4.0)
+    dor-rights-auth (1.5.0)
       nokogiri
     dor-services (9.6.0)
       active-fedora (>= 8.7.0, < 9)
@@ -471,6 +471,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano (~> 3.0)
+  dor-rights-auth (~> 1.5)
   dor-services (~> 9.0, >= 9.2.1)
   dor-services-client (~> 6.0)
   dor-workflow-client (~> 3.20)

--- a/app/indexers/rights_metadata_datastream_indexer.rb
+++ b/app/indexers/rights_metadata_datastream_indexer.rb
@@ -66,6 +66,10 @@ class RightsMetadataDatastreamIndexer
     # what the other more specific fields return, so discard them
     solr_doc['rights_descriptions_ssim'] -= %w[access_restricted access_restricted_qualified world_qualified]
     solr_doc['rights_descriptions_ssim'] += ['dark (file)'] if dra.index_elements[:terms].include? 'none_read_file'
+    if dra.index_elements[:primary].include? 'cdl_none'
+      solr_doc['rights_descriptions_ssim'] += ['controlled digital lending']
+      solr_doc['rights_descriptions_ssim'] -= ['cdl_none']
+    end
 
     solr_doc['obj_rights_locations_ssim'] = dra.index_elements[:obj_locations] if dra.index_elements[:obj_locations].present?
     solr_doc['file_rights_locations_ssim'] = dra.index_elements[:file_locations] if dra.index_elements[:file_locations].present?

--- a/spec/indexers/rights_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/rights_metadata_datastream_indexer_spec.rb
@@ -96,6 +96,23 @@ RSpec.describe RightsMetadataDatastreamIndexer do
         end
       end
 
+      context 'when it is controlled digital lending' do
+        let(:index_elements) do
+          {
+            primary: 'cdl_none',
+            errors: [],
+            terms: []
+          }
+        end
+
+        it 'indexes correctly into rights_descriptions_ssim' do
+          expect(doc).to match a_hash_including(
+            'rights_primary_ssi' => 'cdl_none',
+            'rights_descriptions_ssim' => ['controlled digital lending']
+          )
+        end
+      end
+
       context 'with file_rights' do
         let(:index_elements) do
           {


### PR DESCRIPTION
## Why was this change made?

Fixes #431 

So that CDL objects are indexed with the correct rights label and show up in argo facets correctly.

Even though we notate cdl_none, there is currently only one flavor of controlled digital lending, with no distinctions between no-download and download.


## How was this change tested?

New unit test added.



## Which documentation and/or configurations were updated?



