### PR TITLE
Remove honeybadger notification for cocina error

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -48,8 +48,7 @@ class DorController < ApplicationController
       obj = Dor.find pid
       cocina = begin
         Success(Dor::Services::Client.object(pid).find)
-      rescue StandardError => e
-        Honeybadger.notify("Unable to convert #{pid} to a cocina model. #{e.message}")
+      rescue StandardError
         Failure(:conversion_error)
       end
     end.format('%n realtime %rs total CPU %ts').gsub(/[()]/, '')


### PR DESCRIPTION


## Why was this change made?

Notifying honeybadger is just a distraction, since we get a notification at the same time from dor-services-app and we write this info into a facet field that is displayed in Argo.

## How was this change tested?



## Which documentation and/or configurations were updated?



