### PR TITLE
Add a docker entrypoint so we don't have pid files lying around

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ COPY Gemfile Gemfile.lock ./
 
 RUN bundle install --without production
 
-COPY . .
+COPY . ./
 
-EXPOSE 3000
-CMD ["rails", "server", "-b", "0.0.0.0"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
## Why was this change made?
So we don't get an error if a pid file is in the container.


## How was this change tested?



## Which documentation and/or configurations were updated?



