### PR TITLE
Don't log errors when AdminPolicies don't have sourceIds

### DIFF
--- a/app/indexers/data_quality_indexer.rb
+++ b/app/indexers/data_quality_indexer.rb
@@ -24,7 +24,7 @@ class DataQualityIndexer
   def source_id_message
     if source_id.present?
       'non-comformant sourceId' unless valid_source_id?
-    elsif !resource.is_a?(Dor::Collection) # Collections are not required to have a sourceId
+    elsif resource.is_a?(Dor::Item) # Collections and APOs are not required to have a sourceId
       'missing sourceId'
     end
   end

--- a/spec/indexers/data_quality_indexer_spec.rb
+++ b/spec/indexers/data_quality_indexer_spec.rb
@@ -63,8 +63,25 @@ RSpec.describe DataQualityIndexer do
       end
     end
 
-    context 'with an invalid sourceId for a Collection' do
+    context 'without a sourceId for a Collection' do
       let(:obj) { Dor::Collection.new(pid: 'druid:rt923jk342') }
+
+      let(:xml) do
+        <<~XML
+          <identityMetadata>
+          </identityMetadata>
+        XML
+      end
+
+      it 'draws the errors' do
+        expect(doc).to eq(
+          'data_quality_ssim' => []
+        )
+      end
+    end
+
+    context 'without a sourceId for an AdminPolicy' do
+      let(:obj) { Dor::AdminPolicyObject.new(pid: 'druid:rt923jk342') }
 
       let(:xml) do
         <<~XML


### PR DESCRIPTION


## Why was this change made?
AdminPolicies don't require a sourceId


## How was this change tested?



## Which documentation and/or configurations were updated?



