### PR TITLE
Don't index data quality on ETD part objects

### DIFF
--- a/app/indexers/data_quality_indexer.rb
+++ b/app/indexers/data_quality_indexer.rb
@@ -11,6 +11,8 @@ class DataQualityIndexer
   # @return [Hash] the partial solr document for identityMetadata
   def to_solr
     Rails.logger.debug "In #{self.class}"
+    # Filter out Items that were attachments for ETDs.  These aren't getting migrated.
+    return {} if resource.relationships(:conforms_to) == ['info:fedora/afmodel:Part']
 
     { 'data_quality_ssim' => messages }
   end

--- a/spec/indexers/data_quality_indexer_spec.rb
+++ b/spec/indexers/data_quality_indexer_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe DataQualityIndexer do
       end
     end
 
+    context 'when the object is part of an ETD' do
+      before do
+        allow(obj).to receive(:relationships).and_return ['info:fedora/afmodel:Part']
+      end
+
+      it 'has none' do
+        expect(doc).to eq({})
+      end
+    end
+
     context 'with an invalid sourceId for a DRO' do
       let(:xml) do
         <<~XML


### PR DESCRIPTION
## Why was this change made?

Many ETD part objects are being called out as invalid, although they will not be migrated off of Fedora.

## How was this change tested?



## Which documentation and/or configurations were updated?



