### PR TITLE
Filter out later etd parts which use has_model not conforms_to

### DIFF
--- a/app/indexers/data_quality_indexer.rb
+++ b/app/indexers/data_quality_indexer.rb
@@ -12,12 +12,18 @@ class DataQualityIndexer
   def to_solr
     Rails.logger.debug "In #{self.class}"
     # Filter out Items that were attachments for ETDs.  These aren't getting migrated.
-    return {} if resource.relationships(:conforms_to) == ['info:fedora/afmodel:Part']
+    return {} if etd_part?
 
     { 'data_quality_ssim' => messages }
   end
 
   private
+
+  def etd_part?
+    # conforms_to is used on earlier objects and later has_model was used
+    resource.relationships(:conforms_to) == ['info:fedora/afmodel:Part'] ||
+      resource.relationships(:has_model) == ['info:fedora/afmodel:Part']
+  end
 
   def messages
     [source_id_message].compact.tap do |messages|

--- a/spec/indexers/data_quality_indexer_spec.rb
+++ b/spec/indexers/data_quality_indexer_spec.rb
@@ -48,12 +48,25 @@ RSpec.describe DataQualityIndexer do
     end
 
     context 'when the object is part of an ETD' do
-      before do
-        allow(obj).to receive(:relationships).and_return ['info:fedora/afmodel:Part']
+      context 'when it uses conforms_to (earlier objects)' do
+        before do
+          allow(obj).to receive(:relationships).with(:conforms_to).and_return ['info:fedora/afmodel:Part']
+        end
+
+        it 'has none' do
+          expect(doc).to eq({})
+        end
       end
 
-      it 'has none' do
-        expect(doc).to eq({})
+      context 'when it uses has_model (latter objects)' do
+        before do
+          allow(obj).to receive(:relationships).with(:conforms_to).and_return []
+          allow(obj).to receive(:relationships).with(:has_model).and_return ['info:fedora/afmodel:Part']
+        end
+
+        it 'has none' do
+          expect(doc).to eq({})
+        end
       end
     end
 


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



