### PR TITLE
Convert DefaultObjectRightsDatastreamIndexer to use Cocina

### DIFF
--- a/app/indexers/default_object_rights_datastream_indexer.rb
+++ b/app/indexers/default_object_rights_datastream_indexer.rb
@@ -1,14 +1,35 @@
 # frozen_string_literal: true
 
 class DefaultObjectRightsDatastreamIndexer
-  attr_reader :resource
+  attr_reader :cocina
 
-  def initialize(resource:, **)
-    @resource = resource
+  def initialize(cocina:, **)
+    @cocina = cocina
   end
 
   # @return [Hash] the partial solr document for defaultObjectRights
   def to_solr
-    resource.defaultObjectRights.to_solr
+    {
+      'use_statement_ssim' => use_statement,
+      'copyright_ssim' => copyright
+    }
+  end
+
+  private
+
+  def xml
+    @xml ||= cocina.administrative.defaultObjectRights
+  end
+
+  def ng_xml
+    @ng_xml ||= Nokogiri::XML(xml) if xml
+  end
+
+  def use_statement
+    ng_xml.xpath('//rightsMetadata/use/human[@type="useAndReproduction"]').map(&:text)
+  end
+
+  def copyright
+    ng_xml.xpath('//rightsMetadata/copyright/human').map(&:text)
   end
 end

--- a/spec/indexers/default_object_rights_datastream_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_datastream_indexer_spec.rb
@@ -3,23 +3,43 @@
 require 'rails_helper'
 
 RSpec.describe DefaultObjectRightsDatastreamIndexer do
-  let(:obj) do
-    Dor::AdminPolicyObject.new
+  let(:cocina) { instance_double(Cocina::Models::AdminPolicy, administrative: administrative) }
+  let(:administrative) { instance_double(Cocina::Models::AdminPolicyAdministrative, defaultObjectRights: xml) }
+  let(:xml) do
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <rightsMetadata>
+         <access type="discover">
+            <machine>
+               <world/>
+            </machine>
+         </access>
+         <access type="read">
+            <machine>
+               <world/>
+            </machine>
+         </access>
+         <use>
+            <human type="useAndReproduction">Rights are owned by Stanford University Libraries.</human>
+         </use>
+         <copyright>
+            <human>Additional copyright info</human>
+         </copyright>
+      </rightsMetadata>
+    XML
   end
-  let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
+  let(:indexer) do
+    described_class.new(resource: obj, cocina: cocina)
+  end
 
   describe '#to_solr' do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina)
+      ).new(id: 'druid:ab123cd4567', resource: instance_double(Dor::AdminPolicyObject), cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
-
-    before do
-      obj.use_statement = 'Rights are owned by Stanford University Libraries.'
-      obj.copyright_statement = 'Additional copyright info'
-    end
 
     it 'makes a solr doc' do
       expect(doc).to match a_hash_including('use_statement_ssim' =>

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -146,7 +146,8 @@ RSpec.describe Indexer do
           'version' => 1,
           'label' => 'testing',
           'administrative' => {
-            'hasAdminPolicy' => apo_id
+            'hasAdminPolicy' => apo_id,
+            'defaultObjectRights' => '<rightsMetadata/>'
           },
           'description' => {
             'title' => [{ 'value' => 'Test obj' }]
@@ -167,7 +168,8 @@ RSpec.describe Indexer do
           'version' => 1,
           'label' => 'testing',
           'administrative' => {
-            'hasAdminPolicy' => apo_id
+            'hasAdminPolicy' => apo_id,
+            'defaultObjectRights' => '<rightsMetadata/>'
           },
           'description' => {
             'title' => [{ 'value' => 'Test obj' }]


### PR DESCRIPTION
## Why was this change made?

Decouples from dor-services.

## How was this change tested?



## Which documentation and/or configurations were updated?



