### PR TITLE
Convert content metadata indexer to completely decouple from Fedora.

### DIFF
--- a/app/indexers/content_metadata_datastream_indexer.rb
+++ b/app/indexers/content_metadata_datastream_indexer.rb
@@ -1,64 +1,69 @@
 # frozen_string_literal: true
 
 class ContentMetadataDatastreamIndexer
-  attr_reader :resource, :cocina
+  attr_reader :cocina
 
-  def initialize(resource:, cocina:, id:)
-    @resource = resource
+  def initialize(cocina:, **)
     @cocina = cocina
   end
 
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/PerceivedComplexity
   # @return [Hash] the partial solr document for contentMetadata
   def to_solr
-    return {} unless doc.root['type']
-
-    counts = Hash.new(0)                # default count is zero
-    resource_type_counts = Hash.new(0)  # default count is zero
-
-    file_sets = cocina.structural.contains
-    counts['resource'] = file_sets.size
-    files = file_sets.flat_map { |fs| fs.structural.contains }
-    counts['content_file'] = files.size
-    preserved_files = files.select { |file| file.administrative.sdrPreserve }
-    preserved_size = preserved_files.sum(&:size)
-    shelved_files = files.select { |file| file.administrative.shelve }
-    counts['shelved_file'] = shelved_files.size
-    mime_types = files.map(&:hasMimeType)
-    file_roles = files.map(&:use).compact
-    first_shelved_image = shelved_files.find { |file| file.filename.end_with?('jp2') }&.filename
-
-    doc.xpath('contentMetadata/resource').each do |resource|
-      resource_type_counts[resource['type']] += 1 if resource['type']
-    end
-    solr_doc = {
-      'content_type_ssim' => doc.root['type'],
-      'content_file_mimetypes_ssim' => mime_types.to_a,
-      'content_file_count_itsi' => counts['content_file'],
-      'shelved_content_file_count_itsi' => counts['shelved_file'],
-      'resource_count_itsi' => counts['resource'],
-      'preserved_size_dbtsi' => preserved_size # double (trie) to support very large sizes
+    {
+      'content_type_ssim' => type(cocina.type),
+      'content_file_mimetypes_ssim' => files.map(&:hasMimeType),
+      'content_file_count_itsi' => files.size,
+      'shelved_content_file_count_itsi' => shelved_files.size,
+      'resource_count_itsi' => file_sets.size,
+      'preserved_size_dbtsi' => preserved_files.sum(&:size), # double (trie) to support very large sizes
+      'content_file_roles_ssim' => files.map(&:use).compact,
+      # first_shelved_image is neither indexed nor multiple
+      'first_shelved_image_ss' => first_shelved_image
     }
-    solr_doc['resource_types_ssim'] = resource_type_counts.keys unless resource_type_counts.empty?
-    solr_doc['content_file_roles_ssim'] = file_roles.to_a unless file_roles.empty?
-    resource_type_counts.each do |key, count|
-      solr_doc["#{key}_resource_count_itsi"] = count
-    end
-    # first_shelved_image is neither indexed nor multiple
-    solr_doc['first_shelved_image_ss'] = first_shelved_image unless first_shelved_image.nil?
-    solr_doc
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 
-  def doc
-    @doc ||= resource.contentMetadata.ng_xml
+  def first_shelved_image
+    shelved_files.find { |file| file.filename.end_with?('jp2') }&.filename
+  end
+
+  def shelved_files
+    files.select { |file| file.administrative.shelve }
+  end
+
+  def preserved_files
+    files.select { |file| file.administrative.sdrPreserve }
+  end
+
+  def files
+    @files ||= file_sets.flat_map { |fs| fs.structural.contains }
+  end
+
+  def file_sets
+    @file_sets ||= cocina.structural.contains
+  end
+
+  def type(object_type)
+    case object_type
+    when Cocina::Models::Vocab.image, Cocina::Models::Vocab.manuscript
+      'image'
+    when Cocina::Models::Vocab.book
+      'book'
+    when Cocina::Models::Vocab.map
+      'map'
+    when Cocina::Models::Vocab.three_dimensional
+      '3d'
+    when Cocina::Models::Vocab.media
+      'media'
+    when Cocina::Models::Vocab.webarchive_seed
+      'webarchive-seed'
+    when Cocina::Models::Vocab.geo
+      'geo'
+    when Cocina::Models::Vocab.document
+      'document'
+    else
+      'file'
+    end
   end
 end

--- a/spec/indexers/content_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/content_metadata_datastream_indexer_spec.rb
@@ -3,31 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ContentMetadataDatastreamIndexer do
-  let(:xml) do
-    <<~XML
-            <?xml version="1.0"?>
-      <contentMetadata objectId="druid:gw177fc7976" type="map" stacks="/specialstack">
-      <resource id="0001" sequence="1" type="image">
-      <file format="JPEG2000" id="gw177fc7976_05_0001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes" size="5143883">
-      <imageData height="4580" width="5939"/>
-      <checksum type="md5">3d3ff46d98f3d517d0bf086571e05c18</checksum>
-      <checksum type="sha1">ca1eb0edd09a21f9dd9e3a89abc790daf4d04916</checksum>
-      </file>
-      <file format="GIF" id="gw177fc7976_05_0001.gif" mimetype="image/gif" preserve="no" publish="no" shelve="no" size="4128877" role="derivative">
-      <imageData height="4580" width="5939"/>
-      <checksum type="md5">406d5d80fdd9ecc0352d339badb4a8fb</checksum>
-      <checksum type="sha1">61940d4fad097cba98a3e9dd9f12a90dde0be1ac</checksum>
-      </file>
-      <file format="TIFF" id="gw177fc7976_00_0001.tif" mimetype="image/tiff" preserve="yes" publish="no" shelve="no" size="81630420">
-      <imageData height="4580" width="5939"/>
-      <checksum type="md5">81ccd17bccf349581b779615e82a0366</checksum>
-      <checksum type="sha1">12586b624540031bfa3d153299160c4885c3508c</checksum>
-      </file>
-      </resource>
-      </contentMetadata>
-    XML
-  end
-
   let(:json) do
     <<~JSON
       {
@@ -164,10 +139,6 @@ RSpec.describe ContentMetadataDatastreamIndexer do
     described_class.new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina)
   end
 
-  before do
-    obj.contentMetadata.content = xml
-  end
-
   describe '#to_solr' do
     subject(:doc) { indexer.to_solr }
 
@@ -179,7 +150,6 @@ RSpec.describe ContentMetadataDatastreamIndexer do
         'shelved_content_file_count_itsi' => 1,
         'resource_count_itsi' => 1,
         'content_file_count_itsi' => 3,
-        'image_resource_count_itsi' => 1,
         'first_shelved_image_ss' => 'gw177fc7976_05_0001.jp2',
         'preserved_size_dbtsi' => 86_774_303
       )


### PR DESCRIPTION
Stop indexing resource counts and resource_types_ssim

## Why was this change made?
The individual count fields are not used, but the resouce_types_ssim is


## How was this change tested?



## Which documentation and/or configurations were updated?



