### PR TITLE
This allows items that are not able to be represented as cocina yet 

### DIFF
--- a/app/indexers/content_metadata_datastream_indexer.rb
+++ b/app/indexers/content_metadata_datastream_indexer.rb
@@ -19,7 +19,7 @@ class ContentMetadataDatastreamIndexer
     counts = Hash.new(0)                # default count is zero
     resource_type_counts = Hash.new(0)  # default count is zero
 
-    file_sets = cocina.value!.structural.contains
+    file_sets = cocina.structural.contains
     counts['resource'] = file_sets.size
     files = file_sets.flat_map { |fs| fs.structural.contains }
     counts['content_file'] = files.size
@@ -29,7 +29,7 @@ class ContentMetadataDatastreamIndexer
     counts['shelved_file'] = shelved_files.size
     mime_types = files.map(&:hasMimeType)
     file_roles = files.map(&:use).compact
-    first_shelved_image = shelved_files.find { |file| file.filename.end_with?('jp2') }.filename
+    first_shelved_image = shelved_files.find { |file| file.filename.end_with?('jp2') }&.filename
 
     doc.xpath('contentMetadata/resource').each do |resource|
       resource_type_counts[resource['type']] += 1 if resource['type']

--- a/app/indexers/data_quality_indexer.rb
+++ b/app/indexers/data_quality_indexer.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class DataQualityIndexer
-  attr_reader :resource, :cocina
+  attr_reader :resource
 
   def initialize(resource:, cocina:)
     @resource = resource
-    @cocina = cocina
   end
 
   # @return [Hash] the partial solr document for identityMetadata
@@ -34,7 +33,7 @@ class DataQualityIndexer
 
   def messages
     [source_id_message].compact.tap do |messages|
-      messages << 'Cocina conversion failed' if cocina.failure?
+      messages << 'Cocina conversion failed'
     end
   end
 

--- a/app/indexers/fedora3_label_indexer.rb
+++ b/app/indexers/fedora3_label_indexer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# indexes the very basics of what we need so that we can find and fix these records
+# prior to migrating away from Fedora 3
+class Fedora3LabelIndexer
+  attr_reader :resource
+
+  def initialize(resource:, cocina:)
+    @resource = resource
+  end
+
+  # @return [Hash] the partial solr document
+  def to_solr
+    Rails.logger.debug "In #{self.class}"
+
+    {}.tap do |solr_doc|
+      solr_doc['obj_label_tesim'] = resource.label
+      solr_doc[SOLR_DOCUMENT_ID.to_sym] = resource.pid
+    end
+  end
+end

--- a/spec/indexers/content_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/content_metadata_datastream_indexer_spec.rb
@@ -157,9 +157,8 @@ RSpec.describe ContentMetadataDatastreamIndexer do
     JSON
   end
 
-  let(:model) { Cocina::Models.build(JSON.parse(json)) }
+  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
   let(:obj) { Dor::Item.new }
-  let(:cocina) { Success(model) }
 
   let(:indexer) do
     described_class.new(resource: obj, cocina: cocina)

--- a/spec/indexers/data_quality_indexer_spec.rb
+++ b/spec/indexers/data_quality_indexer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe DataQualityIndexer do
   let(:obj) { Dor::Item.new(pid: 'druid:rt923jk342') }
-  let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
+  let(:cocina) { None() }
 
   let(:indexer) do
     described_class.new(resource: obj, cocina: cocina)
@@ -43,7 +43,7 @@ RSpec.describe DataQualityIndexer do
 
     context 'when all fields are present' do
       it 'has none' do
-        expect(doc).to eq('data_quality_ssim' => [])
+        expect(doc).to eq('data_quality_ssim' => ['Cocina conversion failed'])
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe DataQualityIndexer do
 
       it 'draws the errors' do
         expect(doc).to eq(
-          'data_quality_ssim' => ['non-comformant sourceId']
+          'data_quality_ssim' => ['non-comformant sourceId', 'Cocina conversion failed']
         )
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe DataQualityIndexer do
 
       it 'draws the errors' do
         expect(doc).to eq(
-          'data_quality_ssim' => []
+          'data_quality_ssim' => ['Cocina conversion failed']
         )
       end
     end
@@ -123,16 +123,6 @@ RSpec.describe DataQualityIndexer do
           </identityMetadata>
         XML
       end
-
-      it 'draws the errors' do
-        expect(doc).to eq(
-          'data_quality_ssim' => []
-        )
-      end
-    end
-
-    context 'with an failed conversion' do
-      let(:cocina) { Failure(:nope) }
 
       it 'draws the errors' do
         expect(doc).to eq(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.include(Dry::Monads[:result])
+  config.include(Dry::Monads[:maybe])
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
…to have a Solr representation



## Why was this change made?

Prior to this change, there would be an error when indexing this class of objects.

## How was this change tested?



## Which documentation and/or configurations were updated?



