### PR TITLE
Pass identifiers to the indexers

### DIFF
--- a/app/indexers/administrative_metadata_datastream_indexer.rb
+++ b/app/indexers/administrative_metadata_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class AdministrativeMetadataDatastreamIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -7,10 +7,10 @@ class AdministrativeTagIndexer
   TAG_PART_DELIMITER = ' : '
   TAGS_TO_INDEX = ['Project', 'Registered By'].freeze
 
-  attr_reader :resource
+  attr_reader :id
 
-  def initialize(resource:, cocina:)
-    @resource = resource
+  def initialize(id:, **)
+    @id = id
   end
 
   # @return [Hash] the partial solr document for administrative tags
@@ -45,7 +45,7 @@ class AdministrativeTagIndexer
   end
 
   def administrative_tags
-    Dor::Services::Client.object(resource.pid).administrative_tags.list
+    Dor::Services::Client.object(id).administrative_tags.list
   rescue Dor::Services::Client::NotFoundResponse
     []
   end

--- a/app/indexers/composite_indexer.rb
+++ b/app/indexers/composite_indexer.rb
@@ -8,16 +8,19 @@ class CompositeIndexer
     @indexers = indexers
   end
 
-  def new(resource:, cocina:)
-    Instance.new(indexers, resource: resource, cocina: cocina)
+  def new(id:, resource:, cocina:)
+    Instance.new(indexers, id: id, resource: resource, cocina: cocina)
   end
 
   class Instance
-    attr_reader :indexers, :resource
+    attr_reader :indexers
 
-    def initialize(indexers, resource:, cocina:)
-      @resource = resource
-      @indexers = indexers.map { |i| i.new(resource: resource, cocina: cocina) }
+    def initialize(indexers, id:, resource:, cocina:)
+      @indexers = indexers.map do |i|
+        i.new(id: id, resource: resource, cocina: cocina)
+      rescue ArgumentError => e
+        raise ArgumentError, "Unable to initialize #{i}. #{e.message}"
+      end
     end
 
     # @return [Hash] the merged solr document for all the sub-indexers

--- a/app/indexers/content_metadata_datastream_indexer.rb
+++ b/app/indexers/content_metadata_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class ContentMetadataDatastreamIndexer
   attr_reader :resource, :cocina
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, cocina:, id:)
     @resource = resource
     @cocina = cocina
   end

--- a/app/indexers/data_indexer.rb
+++ b/app/indexers/data_indexer.rb
@@ -6,7 +6,7 @@ class DataIndexer
 
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/data_quality_indexer.rb
+++ b/app/indexers/data_quality_indexer.rb
@@ -3,7 +3,7 @@
 class DataQualityIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/default_object_rights_datastream_indexer.rb
+++ b/app/indexers/default_object_rights_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class DefaultObjectRightsDatastreamIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/describable_indexer.rb
+++ b/app/indexers/describable_indexer.rb
@@ -3,7 +3,7 @@
 class DescribableIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/descriptive_metadata_datastream_indexer.rb
+++ b/app/indexers/descriptive_metadata_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class DescriptiveMetadataDatastreamIndexer
   attr_reader :cocina
 
-  def initialize(resource:, cocina:)
+  def initialize(cocina:, **)
     @cocina = cocina
   end
 

--- a/app/indexers/embargo_metadata_datastream_indexer.rb
+++ b/app/indexers/embargo_metadata_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class EmbargoMetadataDatastreamIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/fedora3_label_indexer.rb
+++ b/app/indexers/fedora3_label_indexer.rb
@@ -5,7 +5,7 @@
 class Fedora3LabelIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/identifiable_indexer.rb
+++ b/app/indexers/identifiable_indexer.rb
@@ -22,7 +22,7 @@ class IdentifiableIndexer
   }.freeze
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/identity_metadata_datastream_indexer.rb
+++ b/app/indexers/identity_metadata_datastream_indexer.rb
@@ -5,7 +5,7 @@ class IdentityMetadataDatastreamIndexer
 
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/object_profile_indexer.rb
+++ b/app/indexers/object_profile_indexer.rb
@@ -5,7 +5,7 @@ class ObjectProfileIndexer
 
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/processable_indexer.rb
+++ b/app/indexers/processable_indexer.rb
@@ -5,7 +5,7 @@ class ProcessableIndexer
 
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/provenance_metadata_datastream_indexer.rb
+++ b/app/indexers/provenance_metadata_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class ProvenanceMetadataDatastreamIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/releasable_indexer.rb
+++ b/app/indexers/releasable_indexer.rb
@@ -5,7 +5,7 @@ class ReleasableIndexer
 
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/rights_metadata_datastream_indexer.rb
+++ b/app/indexers/rights_metadata_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class RightsMetadataDatastreamIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/role_metadata_datastream_indexer.rb
+++ b/app/indexers/role_metadata_datastream_indexer.rb
@@ -5,7 +5,7 @@ class RoleMetadataDatastreamIndexer
 
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/version_metadata_datastream_indexer.rb
+++ b/app/indexers/version_metadata_datastream_indexer.rb
@@ -3,7 +3,7 @@
 class VersionMetadataDatastreamIndexer
   attr_reader :resource
 
-  def initialize(resource:, cocina:)
+  def initialize(resource:, **)
     @resource = resource
   end
 

--- a/app/indexers/workflows_indexer.rb
+++ b/app/indexers/workflows_indexer.rb
@@ -2,10 +2,10 @@
 
 # Indexes the objects position in workflows
 class WorkflowsIndexer
-  attr_reader :resource
+  attr_reader :id
 
-  def initialize(resource:, cocina:)
-    @resource = resource
+  def initialize(id:, **)
+    @id = id
   end
 
   # @return [Hash] the partial solr document for workflow concerns
@@ -30,6 +30,6 @@ class WorkflowsIndexer
   # TODO: remove Dor::Workflow::Document
   # @return [Workflow::Response::Workflows]
   def all_workflows
-    @all_workflows ||= WorkflowClientFactory.build.workflow_routes.all_workflows pid: resource.pid
+    @all_workflows ||= WorkflowClientFactory.build.workflow_routes.all_workflows pid: id
   end
 end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -95,9 +95,10 @@ class Indexer
   def self.for(obj, cocina:)
     Rails.logger.debug("Fetching indexer for #{obj.class}")
     if cocina.success?
-      INDEXERS.fetch(obj.class).new(resource: obj, cocina: cocina.value!)
+      result = cocina.value!
+      INDEXERS.fetch(obj.class).new(id: result.externalIdentifier, resource: obj, cocina: result)
     else
-      FALLBACK_INDEXER.new(resource: obj, cocina: cocina.to_maybe)
+      FALLBACK_INDEXER.new(id: obj.pid, resource: obj, cocina: cocina.to_maybe)
     end
   end
 end

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe AdministrativeTagIndexer do
   describe '#to_solr' do
     subject(:document) { indexer.to_solr }
 
-    let(:indexer) { described_class.new(resource: object, cocina: cocina) }
-    let(:object) { Dor::Abstract.new(pid: 'druid:rt923jk234') }
-    let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
+    let(:indexer) { described_class.new(id: 'druid:rt923jk234') }
 
     let(:tags) do
       [

--- a/spec/indexers/composite_indexer_spec.rb
+++ b/spec/indexers/composite_indexer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe CompositeIndexer do
       instance_double(Dor::Workflow::Client::Status, milestones: {}, info: {}, display: 'bad')
     end
     let(:workflow_client) { instance_double(Dor::Workflow::Client, status: status) }
-    let(:doc) { indexer.new(resource: obj, cocina: cocina).to_solr }
+    let(:doc) { indexer.new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina).to_solr }
 
     before do
       allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)

--- a/spec/indexers/content_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/content_metadata_datastream_indexer_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe ContentMetadataDatastreamIndexer do
   let(:obj) { Dor::Item.new }
 
   let(:indexer) do
-    described_class.new(resource: obj, cocina: cocina)
+    described_class.new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina)
   end
 
   before do

--- a/spec/indexers/data_indexer_spec.rb
+++ b/spec/indexers/data_indexer_spec.rb
@@ -8,15 +8,11 @@ RSpec.describe DataIndexer do
   end
   let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
 
-  let(:indexer) do
-    described_class.new(resource: obj, cocina: cocina)
-  end
-
   describe '#to_solr' do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj, cocina: cocina)
+      ).new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/default_object_rights_datastream_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_datastream_indexer_spec.rb
@@ -8,15 +8,11 @@ RSpec.describe DefaultObjectRightsDatastreamIndexer do
   end
   let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
 
-  let(:indexer) do
-    described_class.new(resource: obj, cocina: cocina)
-  end
-
   describe '#to_solr' do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj, cocina: cocina)
+      ).new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/object_profile_indexer_spec.rb
+++ b/spec/indexers/object_profile_indexer_spec.rb
@@ -8,15 +8,11 @@ RSpec.describe ObjectProfileIndexer do
   end
   let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
 
-  let(:indexer) do
-    described_class.new(resource: obj, cocina: cocina)
-  end
-
   describe '#to_solr' do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(resource: obj, cocina: cocina)
+      ).new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/processable_indexer_spec.rb
+++ b/spec/indexers/processable_indexer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ProcessableIndexer do
-  let(:indexer) { described_class.new(resource: obj, cocina: cocina) }
+  let(:indexer) { described_class.new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina) }
   let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
 
   describe '#to_solr' do
@@ -29,7 +29,7 @@ RSpec.describe ProcessableIndexer do
         let(:indexer) do
           CompositeIndexer.new(
             described_class
-          ).new(resource: obj, cocina: cocina)
+          ).new(id: 'druid:ab123cd4567', resource: obj, cocina: cocina)
         end
 
         let(:status) do

--- a/spec/indexers/workflows_indexer_spec.rb
+++ b/spec/indexers/workflows_indexer_spec.rb
@@ -3,10 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe WorkflowsIndexer do
-  let(:obj) { instance_double(Dor::Item, pid: 'druid:ab123cd4567') }
-  let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
-
-  let(:indexer) { described_class.new(resource: obj, cocina: cocina) }
+  let(:indexer) { described_class.new(id: 'druid:ab123cd4567') }
 
   describe '#to_solr' do
     let(:solr_doc) { indexer.to_solr }

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Indexer do
   subject(:indexer) { described_class.for(model, cocina: Success(cocina)) }
 
+  let(:druid) { 'druid:xx999xx9999' }
   let(:processable) do
     instance_double(ProcessableIndexer, to_solr: { 'milestones_ssim' => %w[foo bar] })
   end
@@ -26,43 +27,43 @@ RSpec.describe Indexer do
   end
 
   context 'when the model is an item' do
-    let(:model) { Dor::Item.new(pid: 'druid:xx999xx9999') }
-    let(:cocina) { instance_double(Cocina::Models::DRO) }
+    let(:model) { Dor::Item.new(pid: druid) }
+    let(:cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is an admin policy' do
-    let(:model) { Dor::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
-    let(:cocina) { instance_double(Cocina::Models::AdminPolicy) }
+    let(:model) { Dor::AdminPolicyObject.new(pid: druid) }
+    let(:cocina) { instance_double(Cocina::Models::AdminPolicy, externalIdentifier: druid) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is a hydrus item' do
     let(:model) { Hydrus::Item.new }
-    let(:cocina) { instance_double(Cocina::Models::DRO) }
+    let(:cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is a hydrus apo' do
-    let(:model) { Hydrus::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
-    let(:cocina) { instance_double(Cocina::Models::AdminPolicy) }
+    let(:model) { Hydrus::AdminPolicyObject.new(pid: druid) }
+    let(:cocina) { instance_double(Cocina::Models::AdminPolicy, externalIdentifier: druid) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is a collection' do
     let(:model) { Dor::Collection.new }
-    let(:cocina) { instance_double(Cocina::Models::Collection) }
+    let(:cocina) { instance_double(Cocina::Models::Collection, externalIdentifier: druid) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is an agreement' do
     let(:model) { Dor::Agreement.new }
-    let(:cocina) { instance_double(Cocina::Models::DRO) }
+    let(:cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
@@ -90,12 +91,12 @@ RSpec.describe Indexer do
         model.contentMetadata.contentType = ['image']
       end
 
-      let(:model) { Dor::Item.new(pid: 'druid:xx999xx9999') }
+      let(:model) { Dor::Item.new(pid: druid) }
 
       context 'when cocina fetch is successful' do
-        let(:model) { Dor::Item.new(pid: 'druid:xx999xx9999') }
+        let(:model) { Dor::Item.new(pid: druid) }
         let(:cocina) do
-          instance_double(Cocina::Models::DRO, structural: structural, description: description)
+          instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural: structural, description: description)
         end
         let(:description) do
           instance_double(Cocina::Models::Description, subject: [topic])
@@ -110,16 +111,16 @@ RSpec.describe Indexer do
 
       context 'when cocina fails to fetch' do
         let(:indexer) { described_class.for(model, cocina: Failure(:conversion_error)) }
-        let(:model) { Dor::Item.new(pid: 'druid:xx999xx9999') }
+        let(:model) { Dor::Item.new(pid: druid) }
 
         it { is_expected.to include('milestones_ssim', 'released_to_ssim', 'wf_ssim', 'tag_ssim', 'obj_label_tesim', :id) }
       end
     end
 
     context 'when the model is an admin policy' do
-      let(:model) { Dor::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
+      let(:model) { Dor::AdminPolicyObject.new(pid: druid) }
       let(:cocina) do
-        instance_double(Cocina::Models::AdminPolicy, description: description)
+        instance_double(Cocina::Models::AdminPolicy, externalIdentifier: druid, description: description)
       end
 
       let(:description) do
@@ -130,9 +131,9 @@ RSpec.describe Indexer do
     end
 
     context 'when the model is a hydrus apo' do
-      let(:model) { Hydrus::AdminPolicyObject.new(pid: 'druid:xx999xx9999') }
+      let(:model) { Hydrus::AdminPolicyObject.new(pid: druid) }
       let(:cocina) do
-        instance_double(Cocina::Models::AdminPolicy, description: description)
+        instance_double(Cocina::Models::AdminPolicy, externalIdentifier: druid, description: description)
       end
 
       let(:description) do


### PR DESCRIPTION


## Why was this change made?

So the indexers that don't depend on models don't need to use them.

## How was this change tested?



## Which documentation and/or configurations were updated?



