### PR TITLE
Handle the case when an object without identification sub-schema

### DIFF
--- a/app/indexers/identifiable_indexer.rb
+++ b/app/indexers/identifiable_indexer.rb
@@ -52,7 +52,7 @@ class IdentifiableIndexer
 
   # @return [String] calculated value for Solr index
   def identity_metadata_source
-    if cocina.identification.catalogLinks&.any? { |link| link.catalog == 'symphony' }
+    if cocina.identification&.catalogLinks&.any? { |link| link.catalog == 'symphony' }
       'Symphony'
     else
       'DOR'

--- a/spec/indexers/identifiable_indexer_spec.rb
+++ b/spec/indexers/identifiable_indexer_spec.rb
@@ -75,8 +75,6 @@ RSpec.describe IdentifiableIndexer do
   describe '#to_solr' do
     let(:doc) { indexer.to_solr }
     let(:mock_rel_druid) { 'druid:qf999gg9999' }
-    # let(:collection) { instance_double(Dor::Collection, id: mock_rel_druid) }
-    # let(:collections) { [collection] }
 
     let(:related) do
       instance_double(Cocina::Models::AdminPolicy, label: 'Test object')
@@ -143,6 +141,33 @@ RSpec.describe IdentifiableIndexer do
 
     context 'without catalogLinks' do
       let(:identification) { {} }
+
+      it 'indexes metadata source' do
+        expect(doc).to match a_hash_including('metadata_source_ssi' => 'DOR')
+      end
+    end
+
+    context 'with no identification sub-schema' do
+      let(:cocina) do
+        Cocina::Models.build(
+          'externalIdentifier' => druid,
+          'type' => Cocina::Models::Vocab.image,
+          'version' => 1,
+          'label' => 'testing',
+          'access' => {},
+          'administrative' => {
+            'hasAdminPolicy' => apo_id
+          },
+          'description' => {
+            'title' => [{ 'value' => 'Test obj' }],
+            'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
+          },
+          'structural' => {
+            'contains' => [],
+            'isMemberOf' => collections
+          }
+        )
+      end
 
       it 'indexes metadata source' do
         expect(doc).to match a_hash_including('metadata_source_ssi' => 'DOR')


### PR DESCRIPTION
## Why was this change made?
A null pointer error was raised when testing in QA.


## How was this change tested?



## Which documentation and/or configurations were updated?



