### PR TITLE
Remove indexing of 20 percent embargos

### DIFF
--- a/app/indexers/embargo_metadata_datastream_indexer.rb
+++ b/app/indexers/embargo_metadata_datastream_indexer.rb
@@ -11,12 +11,9 @@ class EmbargoMetadataDatastreamIndexer
   # @return [Hash] the partial solr document for embargoMetadata
   def to_solr
     {
-      'embargo_status_ssim' => embargo_status,
-      'twenty_pct_status_ssim' => Array(twenty_pct_status)
+      'embargo_status_ssim' => embargo_status
     }.tap do |solr_doc|
-      rd20 = twenty_pct_release_date
       solr_doc['embargo_release_dtsim'] = Array(release_date.first.utc.strftime('%FT%TZ')) if release_date.first.present?
-      solr_doc['twenty_pct_release_embargo_release_dtsim'] = Array(rd20.utc.strftime('%FT%TZ')) if rd20.present?
     end
   end
 
@@ -26,5 +23,5 @@ class EmbargoMetadataDatastreamIndexer
   # rubocop:enable Lint/UselessAccessModifier
 
   delegate :embargoMetadata, to: :resource
-  delegate :embargo_status, :twenty_pct_status, :twenty_pct_release_date, :release_date, to: :embargoMetadata
+  delegate :embargo_status, :release_date, to: :embargoMetadata
 end

--- a/spec/indexers/embargo_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/embargo_metadata_datastream_indexer_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe EmbargoMetadataDatastreamIndexer do
       <embargoMetadata>
         <status>embargoed</status>
         <releaseDate>2011-10-12T15:47:52-07:00</releaseDate>
-        <twentyPctVisibilityStatus>released</twentyPctVisibilityStatus>
-        <twentyPctVisibilityReleaseDate>2016-10-12T15:47:52-07:00</twentyPctVisibilityReleaseDate>
         <releaseAccess>
           <access type="discover">
             <machine>
@@ -41,11 +39,9 @@ RSpec.describe EmbargoMetadataDatastreamIndexer do
   describe '#to_solr' do
     subject(:doc) { indexer.to_solr }
 
-    it 'has the fields used by argo' do
+    it 'has the fields used by dor-services-app' do
       expect(doc).to eq('embargo_release_dtsim' => ['2011-10-12T22:47:52Z'],
-                        'embargo_status_ssim' => ['embargoed'],
-                        'twenty_pct_status_ssim' => ['released'],
-                        'twenty_pct_release_embargo_release_dtsim' => ['2016-10-12T22:47:52Z'])
+                        'embargo_status_ssim' => ['embargoed'])
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?

These have all converted to regular embargoes. See:
* https://github.com/sul-dlss/dor-services-app/issues/2416
* https://github.com/sul-dlss/dor-services-app/pull/2436

Now we are able to convert the EmbargoMetadataIndexer to use Cocina.

## How was this change tested?



## Which documentation and/or configurations were updated?



