### PR TITLE
Index originInfo derived fields

### DIFF
--- a/app/indexers/descriptive_metadata_datastream_indexer.rb
+++ b/app/indexers/descriptive_metadata_datastream_indexer.rb
@@ -9,10 +9,35 @@ class DescriptiveMetadataDatastreamIndexer
 
   # @return [Hash] the partial solr document for descMetadata
   def to_solr
-    topics = Array(cocina.description.subject).select { |node| node.type == 'topic' }.map(&:value)
     {
+      'originInfo_date_created_tesim' => creation&.date&.map(&:value),
+      'originInfo_publisher_tesim' => publisher_name,
+      'originInfo_place_placeTerm_tesim' => publication&.location&.map(&:value),
       'topic_ssim' => topics,
       'topic_tesim' => topics
     }
+  end
+
+  private
+
+  def publisher_name
+    publisher = Array(publication&.contributor).find { |contributor| contributor.role.any? { |role| role.value == 'publisher' } }
+    Array(publisher&.name).map(&:value)
+  end
+
+  def publication
+    @publication ||= events.find { |node| node.type == 'publication' }
+  end
+
+  def creation
+    events.find { |node| node.type == 'creation' }
+  end
+
+  def topics
+    @topics ||= Array(cocina.description.subject).select { |node| node.type == 'topic' }.map(&:value)
+  end
+
+  def events
+    @events ||= Array(cocina.description.event)
   end
 end

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -111,7 +111,40 @@ RSpec.describe Indexer do
             },
             'description' => {
               'title' => [{ 'value' => 'Test obj' }],
-              'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
+              'subject' => [{ 'type' => 'topic', 'value' => 'word' }],
+              'event' => [
+                {
+                  'type' => 'creation',
+                  'date' => [
+                    {
+                      'value' => '2021-01-01',
+                      'status' => 'primary',
+                      'encoding' => {
+                        'code' => 'w3cdtf'
+                      }
+                    }
+                  ]
+                },
+                {
+                  'type' => 'publication',
+                  'location' => [
+                    {
+                      'value' => 'Moskva'
+                    }
+                  ],
+                  'contributor' => [
+                    {
+                      'name' => [
+                        {
+                          'value' => 'Izdatelʹstvo "Vesʹ Mir"'
+                        }
+                      ],
+                      'type' => 'organization',
+                      'role' => [{ 'value' => 'publisher' }]
+                    }
+                  ]
+                }
+              ]
             },
             'structural' => {
               'contains' => [],
@@ -123,7 +156,13 @@ RSpec.describe Indexer do
           )
         end
 
-        it { is_expected.to include('milestones_ssim', 'released_to_ssim', 'wf_ssim', 'tag_ssim') }
+        it 'has required fields' do
+          expect(solr_doc).to include('milestones_ssim', 'released_to_ssim', 'wf_ssim', 'tag_ssim')
+
+          expect(solr_doc['originInfo_date_created_tesim']).to eq ['2021-01-01']
+          expect(solr_doc['originInfo_publisher_tesim']).to eq ['Izdatelʹstvo "Vesʹ Mir"']
+          expect(solr_doc['originInfo_place_placeTerm_tesim']).to eq ['Moskva']
+        end
       end
 
       context 'when cocina fails to fetch' do


### PR DESCRIPTION


## Why was this change made?
Fixed a regression which caused three fields that argo depends on to not be indexed.
Fixes #521

## How was this change tested?



## Which documentation and/or configurations were updated?



