### PR TITLE
Switches identity metadata datastream indexer to use cocina.

### DIFF
--- a/app/indexers/identity_metadata_datastream_indexer.rb
+++ b/app/indexers/identity_metadata_datastream_indexer.rb
@@ -3,45 +3,61 @@
 class IdentityMetadataDatastreamIndexer
   include SolrDocHelper
 
-  attr_reader :resource
+  attr_reader :cocina_object
 
-  def initialize(resource:, **)
-    @resource = resource
+  def initialize(cocina:, **)
+    @cocina_object = cocina
   end
 
   # @return [Hash] the partial solr document for identityMetadata
   def to_solr
-    solr_doc = {}
-    solr_doc['objectType_ssim'] = resource.identityMetadata.objectType
+    return { 'objectType_ssim' => [object_type] } if object_type == 'adminPolicy' || cocina_object.identification.nil?
 
-    plain_identifiers = []
-    ns_identifiers = []
-    if source_id.present?
-      (name, id) = source_id.split(/:/, 2)
-      plain_identifiers << id
-      ns_identifiers << source_id
-      solr_doc['source_id_ssim'] = [source_id]
-    end
-
-    resource.identityMetadata.otherId.compact.each do |qid|
-      # this section will solrize barcode and catkey, which live in otherId
-      (name, id) = qid.split(/:/, 2)
-      plain_identifiers << id
-      ns_identifiers << qid
-      next unless %w[barcode catkey].include?(name)
-
-      solr_doc["#{name}_id_ssim"] = [id]
-    end
-    solr_doc['dor_id_tesim'] = plain_identifiers
-    solr_doc['identifier_tesim'] = ns_identifiers
-    solr_doc['identifier_ssim'] = ns_identifiers
-
-    solr_doc
+    {
+      'objectType_ssim' => [object_type],
+      'dor_id_tesim' => [source_id_value, barcode, catkey].compact,
+      'identifier_ssim' => prefixed_identifiers,
+      'identifier_tesim' => prefixed_identifiers,
+      'barcode_id_ssim' => [barcode].compact,
+      'catkey_id_ssim' => [catkey].compact,
+      'source_id_ssim' => [source_id].compact
+    }
   end
 
   private
 
   def source_id
-    @source_id ||= resource.identityMetadata.sourceId
+    @source_id ||= cocina_object.identification.sourceId
+  end
+
+  def source_id_value
+    @source_id_value ||= source_id ? source_id.split(/:/, 2)[1] : nil
+  end
+
+  def barcode
+    @barcode ||= cocina_object.identification.barcode
+  end
+
+  def catkey
+    @catkey ||= Array(cocina_object.identification.catalogLinks).find { |link| link.catalog == 'symphony' }&.catalogRecordId
+  end
+
+  def object_type
+    case cocina_object
+    when Cocina::Models::AdminPolicy
+      'adminPolicy'
+    when Cocina::Models::Collection
+      'collection'
+    else
+      'item'
+    end
+  end
+
+  def prefixed_identifiers
+    [].tap do |identifiers|
+      identifiers << source_id if source_id
+      identifiers << "barcode:#{barcode}" if barcode
+      identifiers << "catkey:#{catkey}" if catkey
+    end
   end
 end

--- a/spec/indexers/identity_metadata_datastream_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_datastream_indexer_spec.rb
@@ -3,60 +3,57 @@
 require 'rails_helper'
 
 RSpec.describe IdentityMetadataDatastreamIndexer do
-  let(:obj) { Dor::Item.new(pid: 'druid:rt923jk342') }
-  let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
+  let(:obj) { Dor::Item.new(pid: 'druid:rt923jk3421') }
+
+  let(:cocina) do
+    Cocina::Models.build({
+      externalIdentifier: 'druid:rt923jk3421',
+      type: Cocina::Models::Vocab.book,
+      version: 1,
+      label: 'Squirrels of North America',
+      access: {
+        access: 'world'
+      },
+      administrative: {
+        hasAdminPolicy: 'druid:bd999bd9999'
+      },
+      identification: identification
+    }.with_indifferent_access)
+  end
 
   let(:indexer) do
     described_class.new(resource: obj, cocina: cocina)
-  end
-
-  before do
-    obj.identityMetadata.content = xml
   end
 
   describe '#to_solr' do
     subject(:doc) { indexer.to_solr }
 
     context 'when all fields are present' do
-      let(:xml) do
-        <<~XML
-          <identityMetadata>
-            <objectId>druid:rt923jk342</objectId>
-            <objectType>item</objectType>
-            <objectLabel>google download barcode 36105049267078</objectLabel>
-            <objectCreator>DOR</objectCreator>
-            <citationTitle>Squirrels of North America</citationTitle>
-            <citationCreator>Eder, Tamara, 1974-</citationCreator>
-            <sourceId source="google">STANFORD_342837261527</sourceId>
-            <otherId name="barcode">36105049267078</otherId>
-            <otherId name="catkey">129483625</otherId>
-            <otherId name="uuid">7f3da130-7b02-11de-8a39-0800200c9a66</otherId>
-            <tag>Google Books : Phase 1</tag>
-            <tag>Google Books : Scan source STANFORD</tag>
-            <tag>Project : Beautiful Books</tag>
-            <tag>Registered By : blalbrit</tag>
-            <tag>DPG : Beautiful Books : Octavo : newpri</tag>
-            <tag>Remediated By : 4.15.4</tag>
-            <release displayType="image" release="true" to="Searchworks" what="self" when="2015-07-27T21:44:26Z" who="lauraw15">true</release>
-            <release displayType="image" release="true" to="Some_special_place" what="self" when="2015-08-31T23:59:59" who="atz">true</release>
-          </identityMetadata>
-        XML
+      let(:identification) do
+        {
+          sourceId: 'google:STANFORD_342837261527',
+          catalogLinks: [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '129483625'
+            }
+          ],
+          barcode: '36105049267078'
+        }
       end
 
       it 'has the fields used by argo' do
         expect(doc).to include(
           'barcode_id_ssim' => ['36105049267078'],
           'catkey_id_ssim' => ['129483625'],
-          'dor_id_tesim' => %w[STANFORD_342837261527 36105049267078 129483625
-                               7f3da130-7b02-11de-8a39-0800200c9a66],
+          'dor_id_tesim' => %w[STANFORD_342837261527 36105049267078 129483625],
           'identifier_ssim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
-                                'catkey:129483625', 'uuid:7f3da130-7b02-11de-8a39-0800200c9a66'],
+                                'catkey:129483625'],
           'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
-                                 'catkey:129483625', 'uuid:7f3da130-7b02-11de-8a39-0800200c9a66'],
+                                 'catkey:129483625'],
           'objectType_ssim' => ['item'],
           'source_id_ssim' => ['google:STANFORD_342837261527']
         )
-        expect(doc).not_to include('source_id_errors_ssim')
       end
     end
   end


### PR DESCRIPTION
closes #809

## Why was this change made?
Less Fedora.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


