### PR TITLE
embargo_metadata_indexer uses cocina data instead of active-fedora

### DIFF
--- a/app/indexers/embargo_metadata_indexer.rb
+++ b/app/indexers/embargo_metadata_indexer.rb
@@ -12,9 +12,9 @@ class EmbargoMetadataIndexer
   def to_solr
     {}.tap do |solr_doc|
       embargo_release_date = embargo_release_date(cocina)
-      if future?(embargo_release_date)
+      if embargo_release_date.present?
         solr_doc['embargo_status_ssim'] = ['embargoed']
-        solr_doc['embargo_release_dtsim'] = [embargo_release_date.utc.strftime('%FT%TZ')]
+        solr_doc['embargo_release_dtsim'] = [embargo_release_date.utc.iso8601]
       end
     end
   end
@@ -23,11 +23,5 @@ class EmbargoMetadataIndexer
 
   def embargo_release_date(cocina)
     cocina.access.embargo.releaseDate if cocina.access.embargo&.releaseDate.present?
-  end
-
-  def future?(embargo_release_date)
-    return false unless embargo_release_date
-
-    embargo_release_date > DateTime.now
   end
 end

--- a/spec/indexers/embargo_metadata_indexer_spec.rb
+++ b/spec/indexers/embargo_metadata_indexer_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe EmbargoMetadataIndexer do
     context 'when embargo.releaseDate is in the past' do
       let(:release_date) { '2020-06-06T07:00:00.000+09:00' }
 
-      it 'Solr doc does not have embargo fields' do
-        expect(doc).to eq({})
+      it 'Solr doc has embargo fields' do
+        expect(doc).to eq('embargo_release_dtsim' => ['2020-06-05T22:00:00Z'],
+                          'embargo_status_ssim' => ['embargoed'])
       end
     end
 

--- a/spec/indexers/embargo_metadata_indexer_spec.rb
+++ b/spec/indexers/embargo_metadata_indexer_spec.rb
@@ -3,45 +3,84 @@
 require 'rails_helper'
 
 RSpec.describe EmbargoMetadataIndexer do
-  let(:xml) do
-    <<~XML
-      <?xml version="1.0"?>
-      <embargoMetadata>
-        <status>embargoed</status>
-        <releaseDate>2011-10-12T15:47:52-07:00</releaseDate>
-        <releaseAccess>
-          <access type="discover">
-            <machine>
-              <world />
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world />
-            </machine>
-          </access>
-        </releaseAccess>
-      </embargoMetadata>
-    XML
+  let(:apo_id) { 'druid:gf999hb9999' }
+  let(:druid) { 'druid:zz666yy9999' }
+  let(:release_date) { '2024-06-06' }
+  let(:cocina) do
+    Cocina::Models.build(
+      'type' => Cocina::Models::Vocab.object,
+      'externalIdentifier' => druid,
+      'label' => 'testing embargo indexing',
+      'version' => 1,
+      'access' => {
+        'access' => 'world',
+        'copyright' => 'some student',
+        'useAndReproductionStatement' => 'restricted until embargo lifted',
+        'license' => 'by-nc-nd',
+        'embargo' => {
+          'releaseDate' => release_date,
+          'access' => 'world',
+          'useAndReproductionStatement' => 'freedom reigns'
+        }
+      },
+      'administrative' => {
+        'hasAdminPolicy' => apo_id
+      },
+      'description' => {
+        'title' => [{ 'value' => 'embargo indexing object' }]
+      }
+    )
   end
-
-  let(:obj) { Dor::Item.new }
-  let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
 
   let(:indexer) do
-    described_class.new(resource: obj, cocina: cocina)
-  end
-
-  before do
-    obj.embargoMetadata.content = xml
+    described_class.new(cocina: cocina)
   end
 
   describe '#to_solr' do
     subject(:doc) { indexer.to_solr }
 
-    it 'has the fields used by dor-services-app' do
-      expect(doc).to eq('embargo_release_dtsim' => ['2011-10-12T22:47:52Z'],
-                        'embargo_status_ssim' => ['embargoed'])
+    context 'when embargo.releaseDate is in the future' do
+      let(:release_date) { '2024-06-06T07:00:00.000+09:00' }
+
+      it 'sets both embargo fields in Solr doc' do
+        expect(doc).to eq('embargo_release_dtsim' => ['2024-06-05T22:00:00Z'],
+                          'embargo_status_ssim' => ['embargoed'])
+      end
+    end
+
+    context 'when embargo.releaseDate is in the past' do
+      let(:release_date) { '2020-06-06T07:00:00.000+09:00' }
+
+      it 'Solr doc does not have embargo fields' do
+        expect(doc).to eq({})
+      end
+    end
+
+    context 'when there is no embargo' do
+      let(:cocina) do
+        Cocina::Models.build(
+          'type' => Cocina::Models::Vocab.object,
+          'externalIdentifier' => druid,
+          'label' => 'testing embargo indexing',
+          'version' => 1,
+          'access' => {
+            'access' => 'world',
+            'copyright' => 'some student',
+            'useAndReproductionStatement' => 'restricted until embargo lifted',
+            'license' => 'by-nc-nd'
+          },
+          'administrative' => {
+            'hasAdminPolicy' => apo_id
+          },
+          'description' => {
+            'title' => [{ 'value' => 'embargo indexing object' }]
+          }
+        )
+      end
+
+      it 'Solr doc does not have embargo fields' do
+        expect(doc).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
~~possibly the cause of a flurry of alerts on -qa~~

This has been tested thoroughly by some non-default infrastructure-integration-tests for embargo (for ETD, hydrus, and h2).   Once this is merged, look for a followup PR in infrastructure-integration-tests.

## Why was this change made?

Fixes #508

more decoupling from Fedora3 - don't use it to index embargo information

## How was this change tested?

unit tests and a new integration test (see sul-dlss/infrastructure-integration-test/pull/217) to test it in situ.

## Which documentation and/or configurations were updated?



