### PR TITLE
Support the 'Author' role when indexing authors

### DIFF
--- a/app/services/author_builder.rb
+++ b/app/services/author_builder.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class AuthorBuilder
-  ALLOWED_ROLES = %w[ Author creator ].freeze
+  ALLOWED_ROLES = %w[Author creator].freeze
 
   # @param [Array<Cocina::Models::Contributor>] contributors
   # @returns [String] The partial solr document
   def self.build(contributors)
     contributors
-      .reject { |contributor| contributor.role && !ALLOWED_ROLES.include?(contributor.role.first.value) }
+      .reject { |contributor| contributor.role && ALLOWED_ROLES.exclude?(contributor.role.first.value) }
       .flat_map do |contributor|
         contributor.name.map do |name|
           next name.value if name.value

--- a/app/services/author_builder.rb
+++ b/app/services/author_builder.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 class AuthorBuilder
+  ALLOWED_ROLES = %w[ Author creator ].freeze
+
   # @param [Array<Cocina::Models::Contributor>] contributors
   # @returns [String] The partial solr document
   def self.build(contributors)
     contributors
-      .reject { |contributor| contributor.role && contributor.role.first.value != 'creator' }
+      .reject { |contributor| contributor.role && !ALLOWED_ROLES.include?(contributor.role.first.value) }
       .flat_map do |contributor|
         contributor.name.map do |name|
+          next name.value if name.value
           next unless name.structuredValue
 
           build_name(name.structuredValue)

--- a/spec/services/author_builder_spec.rb
+++ b/spec/services/author_builder_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AuthorBuilder do
   subject { described_class.build(contributors) }
 
-  context 'with an author' do
+  context 'with an creator' do
     let(:contributors) do
       [
         Cocina::Models::Contributor.new(
@@ -44,6 +44,25 @@ RSpec.describe AuthorBuilder do
     end
 
     it { is_expected.to eq ['George, Henry (1839-1897)', 'George, Henry (1862-1916)'] }
+  end
+
+  context 'with an author (example from Hydrus)' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          "name": [{ "value": 'Stanford, Jane Lathrop' }],
+          "type": 'person',
+          "role": [{
+            "value": 'Author',
+            "source": {
+              "code": 'marcrelator'
+            }
+          }]
+        )
+      ]
+    end
+
+    it { is_expected.to eq ['Stanford, Jane Lathrop'] }
   end
 
   context 'with non-author contributors' do


### PR DESCRIPTION


## Why was this change made?

And allow names with basic values.

Fixes the integration test failure for hydrus

## How was this change tested?

Integration test.


## Which documentation and/or configurations were updated?



