### PR TITLE
remove coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,8 @@ end
 
 group :development, :test do
   gem 'byebug'
-  gem 'coveralls', require: false
   gem 'rspec-rails', '~> 3.0'
-  gem 'simplecov', '~> 0.17.1', require: false # 0.18 breaks reporting to coveralls `undefined method `coverage' for #<SimpleCov::SourceFile:0x0000561b4563cd18>`
+  gem 'simplecov', '~> 0.17.1', require: false # https://github.com/codeclimate/test-reporter/issues/413
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,12 +107,6 @@ GEM
     config (3.0.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -265,7 +259,6 @@ GEM
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
     msgpack (1.4.2)
-    multi_json (1.15.0)
     multipart-post (2.1.1)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -443,15 +436,10 @@ GEM
     stanford-mods-normalizer (0.1.0)
       nokogiri (~> 1.8)
     stomp (1.4.10)
-    sync (0.5.0)
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.28.0)
-      sync
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -484,7 +472,6 @@ DEPENDENCIES
   capistrano-shared_configs
   committee
   config
-  coveralls
   dlss-capistrano (~> 3.11)
   dor-rights-auth (~> 1.5)
   dor-services (~> 9.0, >= 9.2.1)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CircleCI](https://circleci.com/gh/sul-dlss/dor_indexing_app.svg?style=svg)](https://circleci.com/gh/sul-dlss/dor_indexing_app)
-[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/dor_indexing_app/badge.svg?branch=main)](https://coveralls.io/github/sul-dlss/dor_indexing_app?branch=main)
+[![Maintainability](https://api.codeclimate.com/v1/badges/955223f2386ae5f10e33/maintainability)](https://codeclimate.com/github/sul-dlss/dor-services-app/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/955223f2386ae5f10e33/test_coverage)](https://codeclimate.com/github/sul-dlss/dor-services-app/test_coverage)
 [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/dor_indexing_app/main/openapi.yml)](http://validator.swagger.io/validator/?url=https://raw.githubusercontent.com/sul-dlss/dor_indexing_app/main/openapi.yml)
 
 # Dor Indexing App

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,12 +21,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'simplecov'
-require 'coveralls'
-Coveralls.wear!('rails')
-SimpleCov.formatters = [
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
 SimpleCov.start 'rails'
 
 require 'webmock/rspec'


### PR DESCRIPTION
## Why was this change made?

Remove coveralls from app in favor of code-climate (which is already setup)

## How was this change tested?



## Which documentation and/or configurations were updated?



