### PR TITLE
add docker build and image push to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,15 @@
 version: 2.1
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: suldlss/dor-indexing-app
+    docker:
+    - image: circleci/buildpack-deps:stretch
 orbs:
   ruby: circleci/ruby@0.1.2
 
 jobs:
-  build:
+  test:
     docker:
       - image: circleci/ruby:2.6.3-stretch-node
     executor: ruby/default
@@ -49,3 +55,87 @@ jobs:
       - run:
           name: Report test coverage results to CodeClimate
           command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
+
+  build-image:
+    executor: docker-publisher
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run:
+        name: Build Docker image
+        command: |
+          docker build -t $IMAGE_NAME:latest .
+    - run:
+        name: Archive Docker image
+        command: |
+          docker save -o app_image.tar $IMAGE_NAME
+    - persist_to_workspace:
+        root: .
+        paths:
+        - ./app_image.tar
+  publish-latest:
+    executor: docker-publisher
+    steps:
+    - attach_workspace:
+        at: /tmp/workspace
+    - setup_remote_docker
+    - run:
+        name: Load archived Docker image
+        command: |
+          docker load -i /tmp/workspace/app_image.tar
+    - run:
+        name: Publish Docker Image to Docker Hub
+        command: |
+          echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          docker push $IMAGE_NAME:latest
+  publish-tag:
+    executor: docker-publisher
+    steps:
+    - attach_workspace:
+        at: /tmp/workspace
+    - setup_remote_docker
+    - run:
+        name: Load archived Docker image
+        command: |
+          docker load -i /tmp/workspace/app_image.tar
+    - run:
+        name: Publish Docker Image to Docker Hub
+        command: |
+          echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
+          docker push $IMAGE_NAME:$CIRCLE_TAG
+workflows:
+  version: 2
+
+  test:
+    jobs:
+    - test
+
+  build:
+    jobs:
+    - build-image:
+        filters:
+          branches:
+            only: main
+    - publish-latest:
+        requires:
+        - build-image
+        filters:
+          branches:
+            only: main
+  build-tags:
+    jobs:
+    - build-image:
+        filters:
+          tags:
+            only: /^[0-9]+\.[0-9]+\.[0-9]+/
+          branches:
+            ignore: /.*/
+    - publish-tag:
+        requires:
+        - build-image
+        filters:
+          tags:
+            only: /^[0-9]+\.[0-9]+\.[0-9]+/
+          branches:
+            ignore: /.*/


### PR DESCRIPTION
## Why was this change made?

Fixes #548 - add docker image build and push to circleCI

NOTE: To match what is in dor-services-app, the CircleCI workflow that runs tests was renamed from "build" to "test", with "build" becoming the docker image build.  The new docker "build" workflow is set to only run on the "main" branch, so will not run in this PR.  This means the "build" workflow from CircleCI will not run in this PR and look likes it's hung.  Once merged, we should update the branch protection to require "ci/circleci: test" instead of "ci/circleci: build" here: https://github.com/sul-dlss/dor_indexing_app/settings/branch_protection_rules/414234

## How was this change tested?



## Which documentation and/or configurations were updated?



