### PR TITLE
unpin coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ end
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails', '~> 3.0'
-  gem 'simplecov', '~> 0.17.1', require: false # https://github.com/codeclimate/test-reporter/issues/413
+  gem 'simplecov'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,11 +409,12 @@ GEM
       mime-types
       nokogiri
       rest-client
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     solrizer (3.4.1)
       activesupport
       daemons
@@ -494,7 +495,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  simplecov (~> 0.17.1)
+  simplecov
   webmock
 
 BUNDLED WITH


### PR DESCRIPTION
## Why was this change made?

We don't need to pin coveralls anymore now that we switched from coveralls to code climate


## How was this change tested?



## Which documentation and/or configurations were updated?



