### PR TITLE
Index the model for items that fail validation

### DIFF
--- a/app/indexers/fedora3_label_indexer.rb
+++ b/app/indexers/fedora3_label_indexer.rb
@@ -15,6 +15,7 @@ class Fedora3LabelIndexer
 
     {}.tap do |solr_doc|
       solr_doc['obj_label_tesim'] = resource.label
+      solr_doc['has_model_ssim'] = resource.class.to_class_uri
       solr_doc['modified_latest_dttsi'] = resource.modified_date.to_datetime.utc.strftime('%FT%TZ')
       solr_doc[SOLR_DOCUMENT_ID.to_sym] = resource.pid
       solr_doc['current_version_isi'] = resource.current_version # Argo Facet field "Version"

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Indexer do
         let(:indexer) { described_class.for(model, cocina_with_metadata: Failure(:conversion_error)) }
         let(:model) { Dor::Item.new(pid: druid) }
 
-        it { is_expected.to include('milestones_ssim', 'released_to_ssim', 'wf_ssim', 'tag_ssim', 'obj_label_tesim', :id) }
+        it { is_expected.to include('milestones_ssim', 'released_to_ssim', 'wf_ssim', 'tag_ssim', 'obj_label_tesim', 'has_model_ssim', :id) }
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

Lots of items are failing on qa/stage with:
```
Solr document (id: druid:nb022qg2431) is missing required has_model_ssim field.
```

## How was this change tested?



## Which documentation and/or configurations were updated?



