### PR TITLE
use ruby hashes for descriptive metadata in cocina

### DIFF
--- a/spec/indexers/descriptive_metadata/genre_spec.rb
+++ b/spec/indexers/descriptive_metadata/genre_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "hasAdminPolicy": "druid:zx485kb6348",
           "partOfProject": "H2"
         },
-        "description": {
-          #{description}
-        },
+        "description": #{JSON.generate(description)},
         "identification": {
           "sourceId": "hydrus:object-6"
         },
@@ -72,198 +70,195 @@ RSpec.describe DescriptiveMetadataIndexer do
       }
     JSON
   end
+  let(:doc) { indexer.to_solr }
 
-  describe 'genre mappings from Cocina to Solr' do
-    describe 'sw_genre_ssim' do
-      let(:doc) { indexer.to_solr }
-
-      context 'when single genre' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "value": "photographs",
-                "type": "genre"
-              }
-            ]
-          JSON
-        end
-
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => ['photographs'])
-        end
+  describe 'genre mappings from Cocina to Solr sw_genre_ssim' do
+    context 'when single genre' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              value: 'photographs',
+              type: 'genre'
+            }
+          ]
+        }
       end
 
-      context 'when multiple genres' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "value": "photographs",
-                "type": "genre"
-              },
-              {
-                "value": "ambrotypes",
-                "type": "genre"
-              }
-            ]
-          JSON
-        end
+      xit 'uses genre value' do
+        expect(doc).to include('sw_genre_ssim' => ['photographs'])
+      end
+    end
 
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => %w[photographs ambrotypes])
-        end
+    context 'when multiple genres' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              value: 'photographs',
+              type: 'genre'
+            },
+            {
+              value: 'ambrotypes',
+              type: 'genre'
+            }
+          ]
+        }
       end
 
-      context 'when multilingual' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "parallelValue": [
-                  {
-                    "value": "photographs",
-                    "type": "genre"
-                  },
-                  {
-                    "value": "фотографии",
-                    "type": "genre"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      xit 'uses both genre values' do
+        expect(doc).to include('sw_genre_ssim' => %w[photographs ambrotypes])
+      end
+    end
 
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => %w[photographs фотографии])
-        end
+    context 'when multilingual' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              parallelValue: [
+                {
+                  value: 'photographs',
+                  type: 'genre'
+                },
+                {
+                  value: 'фотографии',
+                  type: 'genre'
+                }
+              ]
+            }
+          ]
+        }
       end
 
-      context 'when genre term is capitalized' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "value": "Photographs",
-                "type": "genre",
-                "displayLabel": "Image type"
-              }
-            ]
-          JSON
-        end
+      xit 'uses both genre values' do
+        expect(doc).to include('sw_genre_ssim' => %w[photographs фотографии])
+      end
+    end
 
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => ['Photographs'])
-        end
+    context 'when genre term is capitalized' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              value: 'Photographs',
+              type: 'genre',
+              displayLabel: 'Image type'
+            }
+          ]
+        }
       end
 
-      context 'when thesis (case-insensitive)' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "value": "Thesis",
-                "type": "genre"
-              }
-            ]
-          JSON
-        end
+      xit 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Photographs'])
+      end
+    end
 
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => ['Thesis'])
-        end
+    context 'when thesis (case-insensitive)' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              value: 'Thesis',
+              type: 'genre'
+            }
+          ]
+        }
       end
 
-      context 'when conference publication (case-insensitive)' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "value": "Conference Publication",
-                "type": "genre"
-              }
-            ]
-          JSON
-        end
+      xit 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Thesis'])
+      end
+    end
 
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => ['Conference proceedings'])
-        end
+    context 'when conference publication (case-insensitive)' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              value: 'Conference Publication',
+              type: 'genre'
+            }
+          ]
+        }
       end
 
-      context 'when government publication (case-insensitive)' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "value": "Government publication",
-                "type": "genre"
-              }
-            ]
-          JSON
-        end
+      xit 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Conference proceedings'])
+      end
+    end
 
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => ['Government document'])
-        end
+    context 'when government publication (case-insensitive)' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              value: 'Government publication',
+              type: 'genre'
+            }
+          ]
+        }
       end
 
-      context 'when technical report (case-insensitive)' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "title"
-              }
-            ],
-            "form": [
-              {
-                "value": "technical report",
-                "type": "genre"
-              }
-            ]
-          JSON
-        end
+      xit 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Government document'])
+      end
+    end
 
-        xit 'populates sw_genre_ssim' do
-          expect(doc).to include('sw_genre_ssim' => ['Technical report'])
-        end
+    context 'when technical report (case-insensitive)' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              value: 'technical report',
+              type: 'genre'
+            }
+          ]
+        }
+      end
+
+      xit 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Technical report'])
       end
     end
   end

--- a/spec/indexers/descriptive_metadata/pub_year_spec.rb
+++ b/spec/indexers/descriptive_metadata/pub_year_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       		"hasAdminPolicy": "druid:zx485kb6348",
       		"partOfProject": "H2"
       	},
-      	"description": {
-          #{description}
-      	},
+      	"description": #{JSON.generate(description)},
       	"identification": {
       		"sourceId": "hydrus:object-6"
       	},
@@ -72,86 +70,85 @@ RSpec.describe DescriptiveMetadataIndexer do
       }
     JSON
   end
+  let(:doc) { indexer.to_solr }
 
-  describe 'pub_year field' do
-    let(:doc) { indexer.to_solr }
-
+  describe 'publication year mappings from Cocina to Solr sw_pub_date_facet_ssi' do
     context 'when event has date.type publication and date.status primary' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "value": "pub dates are fun",
-              "type": "main title"
+              value: 'pub dates are fun',
+              type: 'main title'
             }
           ],
-          "event": [
+          event: [
             {
-              "date": [
+              date: [
                 {
-                  "value": "1827",
-                  "type": "creation"
+                  value: '1827',
+                  type: 'creation'
                 }
               ]
             },
             {
-              "date": [
+              date: [
                 {
-                  "value": "1940",
-                  "type": "publication",
-                  "status": "primary"
+                  value: '1940',
+                  type: 'publication',
+                  status: 'primary'
                 },
                 {
-                  "value": "1942",
-                  "type": "publication"
+                  value: '1942',
+                  type: 'publication'
                 }
               ]
             }
           ]
-        JSON
+        }
       end
 
-      it 'populates sw_pub_date_facet_ssi' do
+      it 'uses value with status primary' do
         expect(doc).to include('sw_pub_date_facet_ssi' => '1940')
       end
 
       context 'when publication date is range (structuredValue)' do
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "pub dates are fun",
-                "type": "main title"
+                value: 'pub dates are fun',
+                type: 'main title'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1940",
-                        "status": "primary",
-                        "type": "start"
+                        value: '1940',
+                        status: 'primary',
+                        type: 'start'
                       },
                       {
-                        "value": "1945",
-                        "type": "end"
+                        value: '1945',
+                        type: 'end'
                       }
                     ],
-                    "type": "publication"
+                    type: 'publication'
                   },
                   {
-                    "value": "1948",
-                    "type": "publication"
+                    value: '1948',
+                    type: 'publication'
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi' do
+        it 'uses value with status primary' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1940')
         end
       end
@@ -159,43 +156,43 @@ RSpec.describe DescriptiveMetadataIndexer do
       context 'when parallelEvent' do
         # based on sf449my9678
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "parallel publication event with status primary pub date"
+                value: 'parallel publication event with status primary pub date'
               }
             ],
-            "event": [
+            event: [
               {
-                "parallelEvent": [
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "1999-09-09",
-                        "type": "publication",
-                        "status": "primary"
+                        value: '1999-09-09',
+                        type: 'publication',
+                        status: 'primary'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi from parallelEvent date status primary with type publication' do
+        it 'uses parallelEvent date status primary with type publication' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1999')
         end
       end
@@ -203,102 +200,102 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     context 'when event.type publication and event has date.type publication but no date.status primary' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": "Work & social justice",
-                  "type": "main title"
+                  value: 'Work & social justice',
+                  type: 'main title'
                 }
               ]
             }
           ],
-          "event": [
+          event: [
             {
-              "date": [
+              date: [
                 {
-                  "value": "2018",
-                  "type": "publication"
+                  value: '2018',
+                  type: 'publication'
                 }
               ]
             },
             {
-              "type": "publication",
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": "2019",
-                  "type": "publication"
+                  value: '2019',
+                  type: 'publication'
                 }
               ]
             },
             {
-              "type": "copyright notice",
-              "note": [
+              type: 'copyright notice',
+              note: [
                 {
-                  "value": "©2020",
-                  "type": "copyright statement"
+                  value: '©2020',
+                  type: 'copyright statement'
                 }
               ]
             }
           ]
-        JSON
+        }
       end
 
-      it 'populates sw_pub_date_facet_ssi' do
+      it 'uses value from type publication' do
         expect(doc).to include('sw_pub_date_facet_ssi' => '2019')
       end
 
       context 'when publication date is range (structuredValue)' do
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "pub dates are fun",
-                "type": "main title"
+                value: 'pub dates are fun',
+                type: 'main title'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "value": "1957",
-                    "type": "publication"
+                    value: '1957',
+                    type: 'publication'
                   }
                 ]
               },
               {
-                "type": "publication",
-                "date": [
+                type: 'publication',
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1940",
-                        "type": "start"
+                        value: '1940',
+                        type: 'start'
                       },
                       {
-                        "value": "1945",
-                        "type": "end"
+                        value: '1945',
+                        type: 'end'
                       }
                     ],
-                    "type": "publication"
+                    type: 'publication'
                   }
                 ]
               },
               {
-                "type": "copyright notice",
-                "note": [
+                type: 'copyright notice',
+                note: [
                   {
-                    "value": "©2020",
-                    "type": "copyright statement"
+                    value: '©2020',
+                    type: 'copyright statement'
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first date of structuredValue' do
+        it 'uses value from first date of structuredValue' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1940')
         end
       end
@@ -306,66 +303,67 @@ RSpec.describe DescriptiveMetadataIndexer do
       context 'when parallelEvent' do
         # based on sf449my9678
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "parallelEvent with no status primary publication date"
+                value: 'parallelEvent with no status primary publication date'
               }
             ],
-            "event": [
+            event: [
               {
-                "parallelEvent": [
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "2020-01-01",
-                        "type": "publication"
+                        value: '2020-01-01',
+                        type: 'publication'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
               },
               {
-                "type": "publication",
-                "parallelEvent": [
+                type: 'publication',
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "2021-01-01",
-                        "type": "publication"
+                        value: '2021-01-01',
+                        type: 'publication'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
-              }                ]
-          JSON
+              }
+            ]
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first publication date of parallelValue of type publication' do
+        it 'uses first publication date of parallelValue of type publication' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '2021')
         end
       end
@@ -373,63 +371,63 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     context 'when event has date.type publication and no event.type publication' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "value": "publication dates R us"
+              value: 'publication dates R us'
             }
           ],
-          "event": [
+          event: [
             {
-              "date": [
+              date: [
                 {
-                  "value": "1980-1984",
-                  "type": "publication"
+                  value: '1980-1984',
+                  type: 'publication'
                 }
               ]
             }
           ]
-        JSON
+        }
       end
 
-      it 'populates sw_pub_date_facet_ssi with first year of 1980-1984' do
+      it 'uses first year of 1980-1984' do
         expect(doc).to include('sw_pub_date_facet_ssi' => '1980')
       end
 
       context 'when publication date is range (structuredValue)' do
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "publication dates R us"
+                value: 'publication dates R us'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1980",
-                        "type": "start"
+                        value: '1980',
+                        type: 'start'
                       },
                       {
-                        "value": "1984",
-                        "type": "end"
+                        value: '1984',
+                        type: 'end'
                       }
                     ],
-                    "type": "publication",
+                    type: 'publication',
                     "encoding": {
-                      "code": "marc"
+                      code: 'marc'
                     }
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first year of structuredValue' do
+        it 'uses first year of structuredValue' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1980')
         end
       end
@@ -437,58 +435,58 @@ RSpec.describe DescriptiveMetadataIndexer do
       context 'when parallelEvent' do
         # based on sf449my9678
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "parallelEvent joy"
+                value: 'parallelEvent joy'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1980",
-                        "type": "start"
+                        value: '1980',
+                        type: 'start'
                       },
                       {
-                        "value": "1984",
-                        "type": "end"
+                        value: '1984',
+                        type: 'end'
                       }
                     ]
                   }
                 ]
               },
               {
-                "parallelEvent": [
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "1966",
-                        "type": "publication"
+                        value: '1966',
+                        type: 'publication'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first publication date of parallelValue' do
+        it 'uses first publication date of parallelValue' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1966')
         end
       end
@@ -496,83 +494,83 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     context 'when event has date.type creation, no date.type publication, and date.status primary' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "value": "pub dates are fun",
-              "type": "main title"
+              value: 'pub dates are fun',
+              type: 'main title'
             }
           ],
-          "event": [
+          event: [
             {
-              "date": [
+              date: [
                 {
-                  "value": "1827",
-                  "type": "validity"
+                  value: '1827',
+                  type: 'validity'
                 }
               ]
             },
             {
-              "date": [
+              date: [
                 {
-                  "value": "1940-01-01",
-                  "type": "creation",
-                  "status": "primary",
+                  value: '1940-01-01',
+                  type: 'creation',
+                  status: 'primary',
                   "encoding": {
-                    "code": "w3cdtf"
+                    code: 'w3cdtf'
                   }
                 },
                 {
-                  "value": "1942",
-                  "type": "creation"
+                  value: '1942',
+                  type: 'creation'
                 }
               ]
             }
           ]
-        JSON
+        }
       end
 
-      it 'populates sw_pub_date_facet_ssi' do
+      it 'uses creation date' do
         expect(doc).to include('sw_pub_date_facet_ssi' => '1940')
       end
 
       context 'when creation date is range (structuredValue)' do
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "pub dates are fun",
-                "type": "main title"
+                value: 'pub dates are fun',
+                type: 'main title'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1940",
-                        "status": "primary",
-                        "type": "start"
+                        value: '1940',
+                        status: 'primary',
+                        type: 'start'
                       },
                       {
-                        "value": "1945",
-                        "type": "end"
+                        value: '1945',
+                        type: 'end'
                       }
                     ],
-                    "type": "creation"
+                    type: 'creation'
                   },
                   {
-                    "value": "1948",
-                    "type": "creation"
+                    value: '1948',
+                    type: 'creation'
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi' do
+        it 'uses creation date with status primary' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1940')
         end
       end
@@ -580,43 +578,43 @@ RSpec.describe DescriptiveMetadataIndexer do
       context 'when parallelEvent' do
         # based on sf449my9678
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "parallel creation event with status primary pub date"
+                value: 'parallel creation event with status primary pub date'
               }
             ],
-            "event": [
+            event: [
               {
-                "parallelEvent": [
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "1999-09-09",
-                        "type": "creation",
-                        "status": "primary"
+                        value: '1999-09-09',
+                        type: 'creation',
+                        status: 'primary'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi from parallelEvent date status primary with type publication' do
+        it 'uses value from parallelEvent date status primary with type publication' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1999')
         end
       end
@@ -624,102 +622,102 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     context 'when event.type creation and event has date.type creation but no date.status primary' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": "Work & social justice",
-                  "type": "main title"
+                  value: 'Work & social justice',
+                  type: 'main title'
                 }
               ]
             }
           ],
-          "event": [
+          event: [
             {
-              "date": [
+              date: [
                 {
-                  "value": "2018",
-                  "type": "creation"
+                  value: '2018',
+                  type: 'creation'
                 }
               ]
             },
             {
-              "type": "creation",
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": "2019",
-                  "type": "creation"
+                  value: '2019',
+                  type: 'creation'
                 }
               ]
             },
             {
-              "type": "copyright notice",
-              "note": [
+              type: 'copyright notice',
+              note: [
                 {
-                  "value": "©2020",
-                  "type": "copyright statement"
+                  value: '©2020',
+                  type: 'copyright statement'
                 }
               ]
             }
           ]
-        JSON
+        }
       end
 
-      it 'populates sw_pub_date_facet_ssi' do
+      it 'uses value with date of type creation from event type of creation' do
         expect(doc).to include('sw_pub_date_facet_ssi' => '2019')
       end
 
       context 'when creation date is range (structuredValue)' do
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "pub dates are fun",
-                "type": "main title"
+                value: 'pub dates are fun',
+                type: 'main title'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "value": "1957",
-                    "type": "creation"
+                    value: '1957',
+                    type: 'creation'
                   }
                 ]
               },
               {
-                "type": "creation",
-                "date": [
+                type: 'creation',
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1940",
-                        "type": "start"
+                        value: '1940',
+                        type: 'start'
                       },
                       {
-                        "value": "1945",
-                        "type": "end"
+                        value: '1945',
+                        type: 'end'
                       }
                     ],
-                    "type": "creation"
+                    type: 'creation'
                   }
                 ]
               },
               {
-                "type": "copyright notice",
-                "note": [
+                type: 'copyright notice',
+                note: [
                   {
-                    "value": "©2020",
-                    "type": "copyright statement"
+                    value: '©2020',
+                    type: 'copyright statement'
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first date of structuredValue' do
+        it 'uses first date of structuredValue of type creation from event of type creation' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1940')
         end
       end
@@ -727,66 +725,67 @@ RSpec.describe DescriptiveMetadataIndexer do
       context 'when parallelEvent' do
         # based on sf449my9678
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "parallelEvent with no status primary creation date"
+                value: 'parallelEvent with no status primary creation date'
               }
             ],
-            "event": [
+            event: [
               {
-                "parallelEvent": [
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "2020-01-01",
-                        "type": "creation"
+                        value: '2020-01-01',
+                        type: 'creation'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
               },
               {
-                "type": "creation",
-                "parallelEvent": [
+                type: 'creation',
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "2021-01-01",
-                        "type": "creation"
+                        value: '2021-01-01',
+                        type: 'creation'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
-              }                ]
-          JSON
+              }
+            ]
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first publication date of parallelValue of type publication' do
+        it 'uses first publication date of parallelValue of type publication' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '2021')
         end
       end
@@ -794,63 +793,63 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     context 'when event has date.type creation and no event.type creation' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "value": "creation dates R us"
+              value: 'creation dates R us'
             }
           ],
-          "event": [
+          event: [
             {
-              "date": [
+              date: [
                 {
-                  "value": "1980-1984",
-                  "type": "creation"
+                  value: '1980-1984',
+                  type: 'creation'
                 }
               ]
             }
           ]
-        JSON
+        }
       end
 
-      it 'populates sw_pub_date_facet_ssi with first year of 1980-1984' do
+      it 'uses first year of 1980-1984 from date with type creation' do
         expect(doc).to include('sw_pub_date_facet_ssi' => '1980')
       end
 
       context 'when creation date is range (structuredValue)' do
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "creation dates R us"
+                value: 'creation dates R us'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1980",
-                        "type": "start"
+                        value: '1980',
+                        type: 'start'
                       },
                       {
-                        "value": "1984",
-                        "type": "end"
+                        value: '1984',
+                        type: 'end'
                       }
                     ],
-                    "type": "creation",
+                    type: 'creation',
                     "encoding": {
-                      "code": "marc"
+                      code: 'marc'
                     }
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first year of structuredValue' do
+        it 'uses first year of structuredValue for date of type creation' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1980')
         end
       end
@@ -858,58 +857,58 @@ RSpec.describe DescriptiveMetadataIndexer do
       context 'when parallelEvent' do
         # based on sf449my9678
         let(:description) do
-          <<~JSON
-            "title": [
+          {
+            title: [
               {
-                "value": "parallelEvent joy"
+                value: 'parallelEvent joy'
               }
             ],
-            "event": [
+            event: [
               {
-                "date": [
+                date: [
                   {
-                    "structuredValue": [
+                    structuredValue: [
                       {
-                        "value": "1980",
-                        "type": "start"
+                        value: '1980',
+                        type: 'start'
                       },
                       {
-                        "value": "1984",
-                        "type": "end"
+                        value: '1984',
+                        type: 'end'
                       }
                     ]
                   }
                 ]
               },
               {
-                "parallelEvent": [
+                parallelEvent: [
                   {
-                    "date": [
+                    date: [
                       {
-                        "value": "1966",
-                        "type": "creation"
+                        value: '1966',
+                        type: 'creation'
                       }
                     ],
-                    "location": [
+                    location: [
                       {
-                        "value": "Chengdu"
+                        value: 'Chengdu'
                       }
                     ]
                   },
                   {
-                    "location": [
+                    location: [
                       {
-                        "value": "成都："
+                        value: '成都：'
                       }
                     ]
                   }
                 ]
               }
             ]
-          JSON
+          }
         end
 
-        it 'populates sw_pub_date_facet_ssi with first publication date of parallelValue' do
+        it 'uses first publication date of parallelValue' do
           expect(doc).to include('sw_pub_date_facet_ssi' => '1966')
         end
       end
@@ -917,30 +916,30 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     context 'when no event with desired date.type and no desired event.type' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": "Work & social justice",
-                  "type": "main title"
+                  value: 'Work & social justice',
+                  type: 'main title'
                 }
               ]
             }
           ],
-          "event": [
+          event: [
             {
-              "type": "publication",
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": "2018",
-                  "status": "primary",
-                  "type": "copyright"
+                  value: '2018',
+                  status: 'primary',
+                  type: 'copyright'
                 }
               ]
             }
           ]
-        JSON
+        }
       end
 
       it 'does not populate sw_pub_date_facet_ssi' do

--- a/spec/indexers/descriptive_metadata/title_spec.rb
+++ b/spec/indexers/descriptive_metadata/title_spec.rb
@@ -3,384 +3,422 @@
 require 'rails_helper'
 
 RSpec.describe DescriptiveMetadataIndexer do
-  describe 'title mappings from Cocina to Solr' do
+  subject(:indexer) { described_class.new(cocina: cocina) }
+
+  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:json) do
+    <<~JSON
+      {
+        "type": "http://cocina.sul.stanford.edu/models/image.jsonld",
+        "externalIdentifier": "druid:qy781dy0220",
+        "label": "SUL Logo for forebrain",
+        "version": 1,
+        "access": {
+          "access": "world",
+          "copyright": "This work is copyrighted by the creator.",
+          "download": "world",
+          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
+        },
+        "administrative": {
+          "hasAdminPolicy": "druid:zx485kb6348",
+          "partOfProject": "H2"
+        },
+        "description": #{JSON.generate(description)},
+        "identification": {
+          "sourceId": "hydrus:object-6"
+        },
+        "structural": {
+          "contains": [{
+            "type": "http://cocina.sul.stanford.edu/models/resources/file.jsonld",
+            "externalIdentifier": "qy781dy0220_1",
+            "label": "qy781dy0220_1",
+            "version": 1,
+            "structural": {
+              "contains": [{
+                "type": "http://cocina.sul.stanford.edu/models/file.jsonld",
+                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
+                "label": "sul-logo.png",
+                "filename": "sul-logo.png",
+                "size": 19823,
+                "version": 1,
+                "hasMimeType": "image/png",
+                "hasMessageDigests": [{
+                    "type": "sha1",
+                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
+                  },
+                  {
+                    "type": "md5",
+                    "digest": "7142ce948827c16120cc9e19b05acd49"
+                  }
+                ],
+                "access": {
+                  "access": "world",
+                  "download": "world"
+                },
+                "administrative": {
+                  "publish": true,
+                  "sdrPreserve": true,
+                  "shelve": true
+                }
+              }]
+            }
+          }],
+          "isMemberOf": [
+            "druid:nb022qg2431"
+          ]
+        }
+      }
+    JSON
+  end
+  let(:doc) { indexer.to_solr }
+
+  describe 'title mappings from Cocina to Solr sw_display_title_tesim' do
     describe 'single untyped title' do
       # Select value; status: primary may or may not be present
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title')
-        end
+      xit 'uses title value' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title')
       end
     end
 
     describe 'single typed title' do
       # Select value; status: primary may or may not be present
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title",
-                "type": "translated"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title',
+              type: 'translated'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title')
-        end
+      xit 'uses title value' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title')
       end
     end
 
     describe 'multiple untyped titles, one primary' do
       # Select primary
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title 1",
-                "status": "primary"
-              },
-              {
-                "value": "Title 2"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title 1',
+              status: 'primary'
+            },
+            {
+              value: 'Title 2'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses value from title with status primary' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'multiple untyped titles, none primary' do
       # Select first
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title 1"
-              },
-              {
-                "value": "Title 2"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title 1'
+            },
+            {
+              value: 'Title 2'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses first value' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'multiple typed and untyped titles, one primary' do
-      # Select primary
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title 1",
-                "type": "translated",
-                "status": "primary"
-              },
-              {
-                "value": "Title 2"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title 1',
+              type: 'translated',
+              status: 'primary'
+            },
+            {
+              value: 'Title 2'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses value from title with status primary' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'multiple typed and untyped titles, none primary' do
       # Select first without type
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title 1",
-                "type": "alternative"
-              },
-              {
-                "value": "Title 2"
-              },
-              {
-                "value": "Title 3"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title 1',
+              type: 'alternative'
+            },
+            {
+              value: 'Title 2'
+            },
+            {
+              value: 'Title 3'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 2')
-        end
+      xit 'uses value from first title without type' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 2')
       end
     end
 
     describe 'multiple typed titles, one primary' do
       # Select primary
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title 1",
-                "type": "translated",
-                "status": "primary"
-              },
-              {
-                "value": "Title 2",
-                "type": "alternative"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title 1',
+              type: 'translated',
+              status: 'primary'
+            },
+            {
+              value: 'Title 2',
+              type: 'alternative'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses value from title with status primary' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'multiple typed titles, none primary' do
       # Select first
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title 1",
-                "type": "translated"
-              },
-              {
-                "value": "Title 2",
-                "type": "alternative"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title 1',
+              type: 'translated'
+            },
+            {
+              value: 'Title 2',
+              type: 'alternative'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses value from first title' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'nonsorting character count' do
       # Note doesn't matter for display value
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "A title",
-                "note": [
-                  {
-                    "type": "nonsorting character count",
-                    "value": "2"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'A title',
+              note: [
+                {
+                  type: 'nonsorting character count',
+                  value: '2'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'A title')
-        end
+      xit 'uses full value from title' do
+        expect(doc).to include('sw_display_title_tesim' => 'A title')
       end
     end
 
     describe 'parallelValue with primary on value' do
       # Select primary
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "parallelValue": [
-                  {
-                    "value": "Title 1"
-                    "status": "primary"
-                  },
-                  {
-                    "value": "Title 2"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'Title 1',
+                  status: 'primary'
+                },
+                {
+                  value: 'Title 2'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses value with status primary' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'parallelValue with primary on parallelValue' do
       # Select first value in primary parallelValue
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "parallelValue": [
-                  {
-                    "value": "Title 1"
-                  },
-                  {
-                    "value": "Title 2"
-                  }
-                ],
-                "status": "primary"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'Title 1'
+                },
+                {
+                  value: 'Title 2'
+                }
+              ],
+              status: 'primary'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses first value from parallelValue with status primary' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'parallelValue with primary on value and parallelValue' do
       # Select primary value in primary parallelValue
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "parallelValue": [
-                  {
-                    "value": "Title 1",
-                    "status": "primary"
-                  },
-                  {
-                    "value": "Title 2"
-                  }
-                ],
-                "status": "primary"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'Title 1',
+                  status: 'primary'
+                },
+                {
+                  value: 'Title 2'
+                }
+              ],
+              status: 'primary'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses value with status primary in parallelValue' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'primary on both parallelValue value and other value' do
       # Select other value with primary; parallelValue primary value is primary within
       # parallelValue but the parallelValue is not itself the primary title
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "parallelValue": [
-                  {
-                    "value": "Title 1",
-                    "status": "primary"
-                  },
-                  {
-                    "value": "Title 2"
-                  }
-                ]
-              },
-              {
-                "value": "Title 3",
-                "status": "primary"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'Title 1',
+                  status: 'primary'
+                },
+                {
+                  value: 'Title 2'
+                }
+              ]
+            },
+            {
+              value: 'Title 3',
+              status: 'primary'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 3')
-        end
+      xit 'uses value from outermost title with status primary' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 3')
       end
     end
 
     describe 'parallelValue with additional value, parallelValue first, no primary' do
       # Select first value, in this case inside parallelValue
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "parallelValue": [
-                  {
-                    "value": "Title 1"
-                  },
-                  {
-                    "value": "Title 2"
-                  }
-                ]
-              },
-              {
-                "value": "Title 3"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'Title 1'
+                },
+                {
+                  value: 'Title 2'
+                }
+              ]
+            },
+            {
+              value: 'Title 3'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 1')
-        end
+      xit 'uses first value' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 1')
       end
     end
 
     describe 'parallelValue with additional value, value first, no primary' do
       # Select first value
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title 3"
-              },
-              {
-                "parallelValue": [
-                  {
-                    "value": "Title 1"
-                  },
-                  {
-                    "value": "Title 2"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title 3'
+            },
+            {
+              parallelValue: [
+                {
+                  value: 'Title 1'
+                },
+                {
+                  value: 'Title 2'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title 3')
-        end
+      xit 'uses first value' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title 3')
       end
     end
 
@@ -396,209 +434,197 @@ RSpec.describe DescriptiveMetadataIndexer do
     # partName or partNumber before nonsorting characters or main title is followed
     #   by period space
     describe 'structuredValue with all parts in common order' do
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "structuredValue": [
-                  {
-                    "value": "A",
-                    "type": "nonsorting characters"
-                  },
-                  {
-                    "value": "title",
-                    "type": "main title"
-                  },
-                  {
-                    "value": "a subtitle",
-                    "type": "subtitle"
-                  },
-                  {
-                    "value": "Vol. 1",
-                    "type": "part number"
-                  },
-                  {
-                    "value": "Supplement",
-                    "type": "part name"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: 'A',
+                  type: 'nonsorting characters'
+                },
+                {
+                  value: 'title',
+                  type: 'main title'
+                },
+                {
+                  value: 'a subtitle',
+                  type: 'subtitle'
+                },
+                {
+                  value: 'Vol. 1',
+                  type: 'part number'
+                },
+                {
+                  value: 'Supplement',
+                  type: 'part name'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'A title : a subtitle. Vol. 1, Supplement')
-        end
+      xit 'constructs title from structuredValue' do
+        expect(doc).to include('sw_display_title_tesim' => 'A title : a subtitle. Vol. 1, Supplement')
       end
     end
 
     describe 'structuredValue with parts in uncommon order' do
       # improvement on stanford_mods in that it respects field order as given
       # based on ckey 9803970
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "structuredValue": [
-                  {
-                    "value": "The",
-                    "type": "nonsorting characters"
-                  },
-                  {
-                    "value": "title",
-                    "type": "main title"
-                  },
-                  {
-                    "value": "Vol. 1",
-                    "type": "part number"
-                  },
-                  {
-                    "value": "Supplement",
-                    "type": "part name"
-                  },
-                  {
-                    "value": "a subtitle",
-                    "type": "subtitle"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: 'The',
+                  type: 'nonsorting characters'
+                },
+                {
+                  value: 'title',
+                  type: 'main title'
+                },
+                {
+                  value: 'Vol. 1',
+                  type: 'part number'
+                },
+                {
+                  value: 'Supplement',
+                  type: 'part name'
+                },
+                {
+                  value: 'a subtitle',
+                  type: 'subtitle'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'The title. Vol. 1, Supplement : a subtitle')
-        end
+      xit 'constructs title from structuredValue, respecting order of occurrence' do
+        expect(doc).to include('sw_display_title_tesim' => 'The title. Vol. 1, Supplement : a subtitle')
       end
     end
 
     describe 'structuredValue with multiple partName and partNumber' do
       # improvement on stanford_mods in that it respects field order as given
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "structuredValue": [
-                  {
-                    "value": "Title",
-                    "type": "main title"
-                  },
-                  {
-                    "value": "Special series",
-                    "type": "part name"
-                  },
-                  {
-                    "value": "Vol. 1",
-                    "type": "part number"
-                  },
-                  {
-                    "value": "Supplement",
-                    "type": "part name"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: 'Title',
+                  type: 'main title'
+                },
+                {
+                  value: 'Special series',
+                  type: 'part name'
+                },
+                {
+                  value: 'Vol. 1',
+                  type: 'part number'
+                },
+                {
+                  value: 'Supplement',
+                  type: 'part name'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title. Special series, Vol. 1, Supplement')
-        end
+      xit 'constructs title from structuredValue, respecting order of occurrence' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title. Special series, Vol. 1, Supplement')
       end
     end
 
     describe 'structuredValue with part before title' do
       # improvement on stanford_mods in that it respects field order as given
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "structuredValue": [
-                  {
-                    "value": "Series 1",
-                    "type": "part number"
-                  },
-                  {
-                    "value": "Title",
-                    "type": "main title"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: 'Series 1',
+                  type: 'part number'
+                },
+                {
+                  value: 'Title',
+                  type: 'main title'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Series 1. Title')
-        end
+      xit 'constructs title from structuredValue, respecting order of occurrence' do
+        expect(doc).to include('sw_display_title_tesim' => 'Series 1. Title')
       end
     end
 
     describe 'structuredValue with nonsorting character count' do
       # improvement on stanford_mods in that it does not force a space separator
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "structuredValue": [
-                  {
-                    "value": "L'",
-                    "type": "nonsorting characters"
-                  },
-                  {
-                    "value": "autre title",
-                    "type": "main title"
-                  }
-                ],
-                "note": [
-                  {
-                    "value": "2",
-                    "type": "nonsorting character count"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: "L'",
+                  type: 'nonsorting characters'
+                },
+                {
+                  value: 'autre title',
+                  type: 'main title'
+                }
+              ],
+              note: [
+                {
+                  value: '2',
+                  type: 'nonsorting character count'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'L\'autre title')
-        end
+      xit 'constructs title from structuredValue, respecting order of occurrence' do
+        expect(doc).to include('sw_display_title_tesim' => 'L\'autre title')
       end
     end
 
     describe 'structuredValue for uniform title' do
       # Omit author name when uniform title is preferred title for display
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "structuredValue": [
-                  {
-                    "value": "Author, An",
-                    "type": "name"
-                  },
-                  {
-                    "value": "Title",
-                    "type": "Title"
-                  }
-                ],
-                "type": "uniform"
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: 'Author, An',
+                  type: 'name'
+                },
+                {
+                  value: 'Title',
+                  type: 'Title'
+                }
+              ],
+              type: 'uniform'
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title')
-        end
+      xit 'constructs title from structuredValue without author name' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title')
       end
     end
 
@@ -606,48 +632,45 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     describe 'punctuation/space in simple value' do
       # strip one or more instances of .,;:/\ plus whitespace at beginning or end of string
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "value": "Title /"
-              }
-            ]
-          JSON
-        end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title')
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title /'
+            }
+          ]
+        }
+      end
+
+      xit 'uses value with trailing punctuation of .,;:/\ stripped' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title')
       end
     end
 
     describe 'punctuation/space in structuredValue' do
       # strip one or more instances of .,;:/\ plus whitespace at beginning or end of string
-      xit 'not implemented' do
-        let(:description) do
-          <<~JSON
-            "title": [
-              {
-                "structuredValue": [
-                  {
-                    "value": "Title.",
-                    "type": "main title"
-                  },
-                  {
-                    "value": ":subtitle",
-                    "type": "subtitle"
-                  }
-                ]
-              }
-            ]
-          JSON
-        end
+      let(:description) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: 'Title.',
+                  type: 'main title'
+                },
+                {
+                  value: ':subtitle',
+                  type: 'subtitle'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        it 'populates sw_display_title_tesim' do
-          expect(doc).to include('sw_display_title_tesim' => 'Title : subtitle')
-        end
+      xit 'uses value with trailing punctuation of .,;:/\ stripped' do
+        expect(doc).to include('sw_display_title_tesim' => 'Title : subtitle')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

For the same reasons we prefer ruby hashes in the dor-services-app for mapping specs -- the syntax highlighting in our IDEs make it a lot easier to spot errors.

- use ruby hashes in specs for cocina descriptions, not JSON
- use better descriptions for specs ("xit" and "it" text)
- reduce spec nesting

## How was this change tested?

same number of unit tests pass.  The event_date_creation spec is being handled in a separate WIP pr.

## Which documentation and/or configurations were updated?



