### PR TITLE
descriptive_meatdata_indexer_spec: switch to ruby hashes

### DIFF
--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -8,296 +8,7 @@ RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
   let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:description) do
-    <<~JSON
-      "title": [{
-        "structuredValue": [{
-            "value": "The",
-            "type": "nonsorting characters"
-          },
-          {
-            "value": "complete works of Henry George",
-            "type": "main title"
-          }
-        ],
-        "note": [{
-          "value": "4",
-          "type": "nonsorting character count"
-        }]
-      }],
-      "contributor": [{
-          "name": [{
-            "structuredValue": [{
-                "value": "George, Henry",
-                "type": "name"
-              },
-              {
-                "value": "1839-1897",
-                "type": "life dates"
-              }
-            ]
-          }],
-          "type": "person",
-          "role": [{
-            "value": "creator",
-            "source": {
-              "code": "marcrelator"
-            }
-          }]
-        },
-        {
-          "name": [{
-            "structuredValue": [{
-                "value": "George, Henry",
-                "type": "name"
-              },
-              {
-                "value": "1862-1916",
-                "type": "life dates"
-              }
-            ]
-          }],
-          "type": "person"
-        }
-      ],
-      "event": [{
-        "type": "publication",
-        "date": [
-          {
-            "value": "1911",
-            "status": "primary",
-            "type": "publication",
-            "encoding": {
-              "code": "marc"
-            }
-          }
-        ],
-        "contributor": [{
-          "name": [{
-            "value": "Doubleday, Page"
-          }],
-          "type": "organization",
-          "role": [{
-            "value": "publisher",
-            "code": "pbl",
-            "uri": "http://id.loc.gov/vocabulary/relators/pbl",
-            "source": {
-              "code": "marcrelator",
-              "uri": "http://id.loc.gov/vocabulary/relators/"
-            }
-          }]
-        }],
-        "location": [{
-            "value": "Garden City, N. Y"
-          },
-          {
-            "code": "xx",
-            "source": {
-              "code": "marccountry"
-            }
-          }
-        ],
-        "note": [{
-            "value": "[Library ed.]",
-            "type": "edition"
-          },
-          {
-            "value": "monographic",
-            "type": "issuance",
-            "source": {
-              "value": "MODS issuance terms"
-            }
-          }
-        ]
-      }],
-      "form": [{
-          "value": "text",
-          "type": "resource type",
-          "source": {
-            "value": "MODS resource types"
-          }
-        },
-        {
-          "value": "electronic",
-          "type": "form",
-          "source": {
-            "code": "marcform"
-          }
-        },
-        {
-          "value": "preservation",
-          "type": "reformatting quality",
-          "source": {
-            "value": "MODS reformatting quality terms"
-          }
-        },
-        {
-          "value": "reformatted digital",
-          "type": "digital origin",
-          "source": {
-            "value": "MODS digital origin terms"
-          }
-        }
-      ],
-      "language": [{
-        "code": "eng",
-        "source": {
-          "code": "iso639-2b"
-        }
-      }],
-      "note": [{
-          "value": "On cover: Complete works of Henry George. Fels fund. Library edition."
-        },
-        {
-          "value": "I. Progress and poverty.--II. Social problems.--III. The land question. Property in land. The condition of labor.--IV. Protection or free trade.--V. A perplexed philosopher [Herbert Spencer]--VI. The science of political economy, books I and II.--VII. The science of political economy, books III to V. \\"Moses\\": a lecture.--VIII. Our land and land policy.--IX-X. The life of Henry George, by his son Henry George, jr.",
-          "type": "table of contents"
-        }
-      ],
-      "identifier": [{
-        "value": "druid:pz263ny9658",
-        "type": "local",
-        "displayLabel": "SUL Resource ID",
-        "note": [{
-          "value": "local",
-          "type": "type",
-          "uri": "http://id.loc.gov/vocabulary/identifiers/local",
-          "source": {
-            "uri": "http://id.loc.gov/vocabulary/identifiers/",
-            "value": "Standard Identifier Schemes"
-          }
-        }]
-      }],
-      "subject": [
-        {
-          "structuredValue": [{
-              "value": "Economics",
-              "type": "topic"
-            },
-            {
-              "value": "1800-1900",
-              "type": "time"
-            }
-          ],
-          "source": {
-            "code": "lcsh"
-          }
-        },
-        {
-          "structuredValue": [{
-              "value": "Economics",
-              "type": "topic"
-            },
-            {
-              "value": "Europe",
-              "type": "place"
-            }
-          ],
-          "source": {
-            "code": "lcsh"
-          }
-        },
-        {
-          "value": "cats",
-          "type": "topic"
-        }
-      ],
-      "purl": "http://purl.stanford.edu/qy781dy0220",
-      "access": {
-        "physicalLocation": [{
-          "value": "Stanford University Libraries"
-        }],
-        "digitalRepository": [{
-          "value": "Stanford Digital Repository"
-        }]
-      },
-      "relatedResource": [{
-          "type": "has original version",
-          "form": [{
-              "value": "print",
-              "type": "form",
-              "source": {
-                "code": "marcform"
-              }
-            },
-            {
-              "value": "10 v. fronts (v. 1-9) ports. 21 cm.",
-              "type": "extent"
-            }
-          ],
-          "adminMetadata": {
-            "contributor": [{
-              "name": [{
-                "code": "YNG",
-                "source": {
-                  "code": "marcorg"
-                }
-              }],
-              "type": "organization",
-              "role": [{
-                "value": "original cataloging agency"
-              }]
-            }],
-            "event": [{
-                "type": "creation",
-                "date": [{
-                  "value": "731210",
-                  "encoding": {
-                    "code": "marc"
-                  }
-                }]
-              },
-              {
-                "type": "modification",
-                "date": [{
-                  "value": "19900625062034.0",
-                  "encoding": {
-                    "code": "iso8601"
-                  }
-                }]
-              }
-            ],
-            "identifier": [{
-                "value": "68184",
-                "type": "SUL catalog key"
-              },
-              {
-                "value": "757655",
-                "type": "OCLC"
-              }
-            ]
-          }
-        },
-        {
-          "purl": "http://purl.stanford.edu/pz263ny9658",
-          "access": {
-            "digitalRepository": [{
-              "value": "Stanford Digital Repository"
-            }]
-          }
-        }
-      ],
-      "adminMetadata": {
-        "contributor": [{
-          "name": [{
-            "value": "DOR_MARC2MODS3-3.xsl Revision 1.1"
-          }]
-        }],
-        "event": [{
-          "type": "creation",
-          "date": [{
-            "value": "2011-02-25T18:20:23.132-08:00",
-            "encoding": {
-              "code": "iso8601"
-            }
-          }]
-        }],
-        "identifier": [{
-          "value": "36105010700545",
-          "type": "Data Provider Digital Object Identifier"
-        }]
-      }
-    JSON
-  end
+  let(:doc) { indexer.to_solr }
   let(:json) do
     <<~JSON
       {
@@ -315,9 +26,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       		"hasAdminPolicy": "druid:zx485kb6348",
       		"partOfProject": "H2"
       	},
-      	"description": {
-          #{description}
-      	},
+      	"description": #{JSON.generate(description)},
       	"identification": {
       		"sourceId": "hydrus:object-6"
       	},
@@ -364,10 +73,320 @@ RSpec.describe DescriptiveMetadataIndexer do
       }
     JSON
   end
+  let(:description) do
+    {
+      title: [
+        {
+          structuredValue: [
+            {
+              value: 'The',
+              type: 'nonsorting characters'
+            },
+            {
+              value: 'complete works of Henry George',
+              type: 'main title'
+            }
+          ],
+          note: [
+            {
+              value: '4',
+              type: 'nonsorting character count'
+            }
+          ]
+        }
+      ],
+      contributor: [
+        {
+          name: [{
+            structuredValue: [
+              {
+                value: 'George, Henry',
+                type: 'name'
+              },
+              {
+                value: '1839-1897',
+                type: 'life dates'
+              }
+            ]
+          }],
+          type: 'person',
+          role: [{
+            value: 'creator',
+            source: {
+              code: 'marcrelator'
+            }
+          }]
+        },
+        {
+          name: [
+            {
+              structuredValue: [
+                {
+                  value: 'George, Henry',
+                  type: 'name'
+                },
+                {
+                  value: '1862-1916',
+                  type: 'life dates'
+                }
+              ]
+            }
+          ],
+          type: 'person'
+        }
+      ],
+      event: [{
+        type: 'publication',
+        date: [
+          {
+            value: '1911',
+            status: 'primary',
+            type: 'publication',
+            encoding: {
+              code: 'marc'
+            }
+          }
+        ],
+        contributor: [{
+          name: [{
+            value: 'Doubleday, Page'
+          }],
+          type: 'organization',
+          role: [{
+            value: 'publisher',
+            code: 'pbl',
+            uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+            source: {
+              code: 'marcrelator',
+              uri: 'http://id.loc.gov/vocabulary/relators/'
+            }
+          }]
+        }],
+        location: [
+          {
+            value: 'Garden City, N. Y'
+          },
+          {
+            code: 'xx',
+            source: {
+              code: 'marccountry'
+            }
+          }
+        ],
+        note: [
+          {
+            value: '[Library ed.]',
+            type: 'edition'
+          },
+          {
+            value: 'monographic',
+            type: 'issuance',
+            source: {
+              value: 'MODS issuance terms'
+            }
+          }
+        ]
+      }],
+      form: [
+        {
+          value: 'text',
+          type: 'resource type',
+          source: {
+            value: 'MODS resource types'
+          }
+        },
+        {
+          value: 'electronic',
+          type: 'form',
+          source: {
+            code: 'marcform'
+          }
+        },
+        {
+          value: 'preservation',
+          type: 'reformatting quality',
+          source: {
+            value: 'MODS reformatting quality terms'
+          }
+        },
+        {
+          value: 'reformatted digital',
+          type: 'digital origin',
+          source: {
+            value: 'MODS digital origin terms'
+          }
+        }
+      ],
+      language: [{
+        code: 'eng',
+        source: {
+          code: 'iso639-2b'
+        }
+      }],
+      note: [
+        {
+          value: 'On cover: Complete works of Henry George. Fels fund. Library edition.'
+        },
+        {
+          value: 'I. Progress and poverty.--II. Social problems.--III. The land question. Property in land. blah blah',
+          type: 'table of contents'
+        }
+      ],
+      identifier: [{
+        value: 'druid:pz263ny9658',
+        type: 'local',
+        displayLabel: 'SUL Resource ID',
+        note: [{
+          value: 'local',
+          type: 'type',
+          uri: 'http://id.loc.gov/vocabulary/identifiers/local',
+          source: {
+            uri: 'http://id.loc.gov/vocabulary/identifiers/',
+            value: 'Standard Identifier Schemes'
+          }
+        }]
+      }],
+      subject: [
+        {
+          structuredValue: [
+            {
+              value: 'Economics',
+              type: 'topic'
+            },
+            {
+              value: '1800-1900',
+              type: 'time'
+            }
+          ],
+          source: {
+            code: 'lcsh'
+          }
+        },
+        {
+          structuredValue: [
+            {
+              value: 'Economics',
+              type: 'topic'
+            },
+            {
+              value: 'Europe',
+              type: 'place'
+            }
+          ],
+          source: {
+            code: 'lcsh'
+          }
+        },
+        {
+          value: 'cats',
+          type: 'topic'
+        }
+      ],
+      purl: 'http://purl.stanford.edu/qy781dy0220',
+      access: {
+        physicalLocation: [{
+          value: 'Stanford University Libraries'
+        }],
+        digitalRepository: [{
+          value: 'Stanford Digital Repository'
+        }]
+      },
+      relatedResource: [
+        {
+          type: 'has original version',
+          form: [
+            {
+              value: 'print',
+              type: 'form',
+              source: {
+                code: 'marcform'
+              }
+            },
+            {
+              value: '10 v. fronts (v. 1-9) ports. 21 cm.',
+              type: 'extent'
+            }
+          ],
+          adminMetadata: {
+            contributor: [{
+              name: [{
+                code: 'YNG',
+                source: {
+                  code: 'marcorg'
+                }
+              }],
+              type: 'organization',
+              role: [{
+                value: 'original cataloging agency'
+              }]
+            }],
+            event: [
+              {
+                type: 'creation',
+                date: [{
+                  value: '731210',
+                  encoding: {
+                    code: 'marc'
+                  }
+                }]
+              },
+              {
+                type: 'modification',
+                date: [{
+                  value: '19900625062034.0',
+                  encoding: {
+                    code: 'iso8601'
+                  }
+                }]
+              }
+            ],
+            identifier: [
+              {
+                value: '68184',
+                type: 'SUL catalog key'
+              },
+              {
+                value: '757655',
+                type: 'OCLC'
+              }
+            ]
+          }
+        },
+        {
+          purl: 'http://purl.stanford.edu/pz263ny9658',
+          access: {
+            digitalRepository: [
+              {
+                value: 'Stanford Digital Repository'
+              }
+            ]
+          }
+        }
+      ],
+      adminMetadata: {
+        contributor: [{
+          name: [{
+            value: 'DOR_MARC2MODS3-3.xsl Revision 1.1'
+          }]
+        }],
+        event: [{
+          type: 'creation',
+          date: [{
+            value: '2011-02-25T18:20:23.132-08:00',
+            encoding: {
+              code: 'iso8601'
+            }
+          }]
+        }],
+        identifier: [{
+          value: '36105010700545',
+          type: 'Data Provider Digital Object Identifier'
+        }]
+      }
+    }
+  end
 
   describe '#to_solr' do
-    let(:doc) { indexer.to_solr }
-
     it 'populates expected fields' do
       expect(doc).to eq(
         'metadata_format_ssim' => 'mods',
@@ -397,42 +416,42 @@ RSpec.describe DescriptiveMetadataIndexer do
 
     context 'with translated title' do
       let(:description) do
-        <<~JSON
-          "title": [
+        {
+          title: [
             {
-              "parallelValue": [
+              parallelValue: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": "Toldot ha-Yehudim be-artsot ha-Islam",
-                      "type": "main title"
+                      value: 'Toldot ha-Yehudim be-artsot ha-Islam',
+                      type: 'main title'
                     },
                     {
-                      "value": "ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19",
-                      "type": "subtitle"
+                      value: 'ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19',
+                      type: 'subtitle'
                     }
                   ]
                 },
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": "תולדות היהודים בארצות האיסלאם",
-                      "type": "main title"
+                      value: 'תולדות היהודים בארצות האיסלאם',
+                      type: 'main title'
                     },
                     {
-                      "value": "העת החדשה עד אמצע המאה ה־19",
-                      "type": "subtitle"
+                      value: 'העת החדשה עד אמצע המאה ה־19',
+                      type: 'subtitle'
                     }
                   ]
                 }
               ]
             },
             {
-              "value": "History of the Jews in the Islamic countries",
-              "type": "alternative"
+              value: 'History of the Jews in the Islamic countries',
+              type: 'alternative'
             }
           ]
-        JSON
+        }
       end
 
       it 'populates expected fields' do


### PR DESCRIPTION
## Why was this change made?

For the same reasons we prefer ruby hashes in the dor-services-app for mapping specs -- the syntax highlighting in our IDEs make it a lot easier to spot errors.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



