### PR TITLE
Index the license using cocina

### DIFF
--- a/app/indexers/rights_metadata_indexer.rb
+++ b/app/indexers/rights_metadata_indexer.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class RightsMetadataIndexer
-  attr_reader :resource
+  attr_reader :resource, :cocina
 
-  def initialize(resource:, **)
+  def initialize(resource:, cocina:, **)
     @resource = resource
+    @cocina = cocina
   end
 
   # @return [Hash] the partial solr document for rightsMetadata
@@ -67,7 +68,7 @@ class RightsMetadataIndexer
       solr_doc[key] = solr_doc[key].reject(&:blank?).flatten unless solr_doc[key].nil?
     end
 
-    solr_doc['use_license_machine_ssi'] = resource.rightsMetadata.use_license.first
+    solr_doc['use_license_machine_ssi'] = license
 
     solr_doc
   end
@@ -75,4 +76,35 @@ class RightsMetadataIndexer
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/PerceivedComplexity
+
+  private
+
+  LICENSE_CODE = {
+    'http://cocina.sul.stanford.edu/licenses/none' => 'none', # Only used in some legacy ETDs.
+    'https://creativecommons.org/licenses/by/3.0/' => 'by',
+    'https://creativecommons.org/licenses/by-sa/3.0/' => 'by-sa',
+    'https://creativecommons.org/licenses/by-nd/3.0/' => 'by-nd',
+    'https://creativecommons.org/licenses/by-nc/3.0/' => 'by-nc',
+    'https://creativecommons.org/licenses/by-nc-sa/3.0/' => 'by-nc-sa',
+    'https://creativecommons.org/licenses/by-nc-nd/3.0/' => 'by-nc-nd',
+    'https://creativecommons.org/licenses/by/4.0/' => 'CC-BY-4.0',
+    'https://creativecommons.org/licenses/by-sa/4.0/' => 'CC-BY-SA-4.0',
+    'https://creativecommons.org/licenses/by-nd/4.0/' => 'CC-BY-ND-4.0',
+    'https://creativecommons.org/licenses/by-nc/4.0/' => 'CC-BY-NC-4.0',
+    'https://creativecommons.org/licenses/by-nc-sa/4.0/' => 'CC-BY-NC-SA-4.0',
+    'https://creativecommons.org/licenses/by-nc-nd/4.0/' => 'CC-BY-NC-ND-4.0',
+    'https://creativecommons.org/publicdomain/mark/1.0/' => 'pdm',
+    'https://creativecommons.org/publicdomain/zero/1.0/' => 'CC0-1.0',
+    'http://opendatacommons.org/licenses/pddl/1.0/' => 'pddl',
+    'http://opendatacommons.org/licenses/by/1.0/' => 'odc-by',
+    'http://opendatacommons.org/licenses/odbl/1.0/' => 'odc-odbl'
+  }.freeze
+
+  # @returns [String] the code if we've defined one, or the URI if we haven't.
+  def license
+    return if cocina.admin_policy?
+
+    uri = cocina.access.license
+    LICENSE_CODE.fetch(uri, uri)
+  end
 end

--- a/spec/indexers/rights_metadata_indexer_spec.rb
+++ b/spec/indexers/rights_metadata_indexer_spec.rb
@@ -29,9 +29,26 @@ RSpec.describe RightsMetadataIndexer do
     XML
   end
 
-  let(:obj) { Dor::Item.new(pid: 'druid:rt923jk342') }
+  let(:obj) { Dor::Item.new(pid: 'druid:rt923jk3429') }
   let(:rights_md_ds) { obj.rightsMetadata }
-  let(:cocina) { Success(instance_double(Cocina::Models::DRO)) }
+  let(:cocina) do
+    Cocina::Models.build(
+      'externalIdentifier' => 'druid:rt923jk3429',
+      'type' => Cocina::Models::Vocab.image,
+      'version' => 1,
+      'label' => 'testing',
+      'access' => {
+        'license' => license
+      },
+      'administrative' => {
+        'hasAdminPolicy' => 'druid:xx000xx0000'
+      },
+      'description' => {
+        'title' => [{ 'value' => 'Test obj' }]
+      }
+    )
+  end
+  let(:license) { 'https://creativecommons.org/publicdomain/zero/1.0/' }
 
   let(:indexer) do
     described_class.new(resource: obj, cocina: cocina)
@@ -48,7 +65,7 @@ RSpec.describe RightsMetadataIndexer do
       expect(doc).to include(
         'copyright_ssim' => ['Copyright © World Trade Organization'],
         'use_statement_ssim' => ['Official WTO documents are free for public use.'],
-        'use_license_machine_ssi' => 'by-nc-nd',
+        'use_license_machine_ssi' => 'CC0-1.0',
         'rights_descriptions_ssim' => ['world']
       )
     end


### PR DESCRIPTION
## Why was this change made?

This decouples from Fedora and gets the new cc0 and all 4.0 Creative Commons licenses to be indexed.



## How was this change tested?



## Which documentation and/or configurations were updated?



