### PR TITLE
guard against nil before downcase

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -111,7 +111,7 @@ class DescriptiveMetadataIndexer
     return ['Book'] if has_resource_type?('text') && has_issuance?('monographic')
     return ['Journal/Periodical'] if has_resource_type?('text') && (has_issuance?('continuing') || has_issuance?('serial') || has_frequency?)
 
-    resource_type_formats = flat_forms_for('resource type').map { |form| FORMAT[form.value.downcase] }.uniq.compact
+    resource_type_formats = flat_forms_for('resource type').map { |form| FORMAT[form.value&.downcase] }.uniq.compact
     resource_type_formats.delete('Book') if resource_type_formats.include?('Archive/Manuscript')
 
     return resource_type_formats if resource_type_formats == ['Book']


### PR DESCRIPTION
## Why was this change made?

Fixes #610 -- guard against nil before downcasing to avoid exceptions.

Validated on -stage

BUT, we should add a test that fails without this and passes with it (currently passes with and without the fix).
And we should also understand why H2 is generating something that has a nil value there.

Here is an example from the integration test: 
- https://sul-purl-stage.stanford.edu/ps141zf3169.xml
- https://sul-h2-stage.stanford.edu/works/13358

Some debugging output for that object in the comments for the ticket: #610


## How was this change tested?



## Which documentation and/or configurations were updated?



