### PR TITLE
Index searchworks format from structured resource type

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -111,7 +111,7 @@ class DescriptiveMetadataIndexer
     return ['Book'] if has_resource_type?('text') && has_issuance?('monographic')
     return ['Journal/Periodical'] if has_resource_type?('text') && (has_issuance?('continuing') || has_issuance?('serial') || has_frequency?)
 
-    resource_type_formats = flat_forms_for('resource type').map { |form| FORMAT[form.value&.downcase] }.uniq.compact
+    resource_type_formats = flat_forms_for('resource type').map { |form| FORMAT[form.value.downcase] }.uniq.compact
     resource_type_formats.delete('Book') if resource_type_formats.include?('Archive/Manuscript')
 
     return resource_type_formats if resource_type_formats == ['Book']
@@ -202,7 +202,7 @@ class DescriptiveMetadataIndexer
   end
 
   def flat_value(value)
-    value.parallelValue || value.groupedValue || Array(value)
+    value.parallelValue || value.groupedValue || value.structuredValue || Array(value)
   end
 
   def name_for(name)

--- a/spec/indexers/descriptive_metadata/format_spec.rb
+++ b/spec/indexers/descriptive_metadata/format_spec.rb
@@ -73,6 +73,34 @@ RSpec.describe DescriptiveMetadataIndexer do
   end
 
   describe 'form/genre mappings from Cocina to Solr sw_format_ssim' do
+    context 'when structuredValue' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Text file houseplant in H2 collection'
+            }
+          ],
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Text',
+                  type: 'type'
+                }
+              ],
+              type: 'resource type',
+              source: { value: 'Stanford self-deposit resource types' }
+            }
+          ]
+        }
+      end
+
+      it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Book'])
+      end
+    end
+
     context 'when dataset' do
       # value "dataset" is case-insensitive
       let(:description) do


### PR DESCRIPTION
Fixes #612

## Why was this change made?

This implements an indexing mapping that helps get some H2 items indexed and rolls back a nil check now that it is no longer needed.


## How was this change tested?

CI and run by @arcadiafalcone 

## Which documentation and/or configurations were updated?

None

