### PR TITLE
Switch to indexing from defaultAccess

### DIFF
--- a/app/indexers/default_object_rights_indexer.rb
+++ b/app/indexers/default_object_rights_indexer.rb
@@ -9,6 +9,8 @@ class DefaultObjectRightsIndexer
 
   # @return [Hash] the partial solr document for defaultObjectRights
   def to_solr
+    return {} unless cocina.administrative.defaultAccess
+
     {
       'use_statement_ssim' => use_statement,
       'copyright_ssim' => copyright
@@ -17,19 +19,11 @@ class DefaultObjectRightsIndexer
 
   private
 
-  def xml
-    @xml ||= cocina.administrative.defaultObjectRights
-  end
-
-  def ng_xml
-    @ng_xml ||= Nokogiri::XML(xml) if xml
-  end
-
   def use_statement
-    ng_xml.xpath('//rightsMetadata/use/human[@type="useAndReproduction"]').map(&:text)
+    cocina.administrative.defaultAccess.useAndReproductionStatement
   end
 
   def copyright
-    ng_xml.xpath('//rightsMetadata/copyright/human').map(&:text)
+    cocina.administrative.defaultAccess.copyright
   end
 end

--- a/spec/indexers/default_object_rights_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_indexer_spec.rb
@@ -3,31 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe DefaultObjectRightsIndexer do
-  let(:cocina) { instance_double(Cocina::Models::AdminPolicy, administrative: administrative) }
-  let(:administrative) { instance_double(Cocina::Models::AdminPolicyAdministrative, defaultObjectRights: xml) }
-  let(:xml) do
-    <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-
-      <rightsMetadata>
-         <access type="discover">
-            <machine>
-               <world/>
-            </machine>
-         </access>
-         <access type="read">
-            <machine>
-               <world/>
-            </machine>
-         </access>
-         <use>
-            <human type="useAndReproduction">Rights are owned by Stanford University Libraries.</human>
-         </use>
-         <copyright>
-            <human>Additional copyright info</human>
-         </copyright>
-      </rightsMetadata>
-    XML
+  let(:cocina) do
+    Cocina::Models.build(
+      'label' => 'The APO',
+      'version' => 1,
+      'type' => Cocina::Models::Vocab.admin_policy,
+      'externalIdentifier' => 'druid:cb123cd4567',
+      'administrative' => {
+        hasAdminPolicy: 'druid:hv992ry2431',
+        defaultAccess: {
+          useAndReproductionStatement: 'Rights are owned by Stanford University Libraries.',
+          copyright: 'Additional copyright info'
+        }
+      }
+    )
   end
 
   describe '#to_solr' do
@@ -40,8 +29,8 @@ RSpec.describe DefaultObjectRightsIndexer do
 
     it 'makes a solr doc' do
       expect(doc).to match a_hash_including('use_statement_ssim' =>
-        ['Rights are owned by Stanford University Libraries.'])
-      expect(doc).to match a_hash_including('copyright_ssim' => ['Additional copyright info'])
+        'Rights are owned by Stanford University Libraries.')
+      expect(doc).to match a_hash_including('copyright_ssim' => 'Additional copyright info')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?
This keeps us from having to parse XML.  This is no longer necessary because DSA breaks these properties out for us.  defaultObjectRights is a deprecated property.

https://github.com/sul-dlss/cocina-models/blob/main/openapi.yml#L204

## How was this change tested?



## Which documentation and/or configurations were updated?



