### PR TITLE
More flexible mapping of marcgac and marc countries.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'honeybadger', '~> 4.5'
 gem 'iso-639', '~> 0.3.5'
 # ISO-639-3
 gem 'language_list'
-gem 'marc-vocab', '~> 0.2.0'
+gem 'marc-vocab', '~> 0.3.0'
 gem 'okcomputer' # for monitoring
 gem 'puma', '~> 3.0' # app server
 gem 'rack-timeout', '~> 0.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marc-vocab (0.2.1)
+    marc-vocab (0.3.0)
     marcel (1.0.1)
     method_source (1.0.0)
     mime-types (3.3.1)
@@ -493,7 +493,7 @@ DEPENDENCIES
   iso-639 (~> 0.3.5)
   language_list
   listen (~> 3.0.5)
-  marc-vocab (~> 0.2.0)
+  marc-vocab (~> 0.3.0)
   newrelic_rpm
   okcomputer
   parse_date

--- a/app/services/geographic_builder.rb
+++ b/app/services/geographic_builder.rb
@@ -48,12 +48,13 @@ class GeographicBuilder
   def place_from_code(node)
     return [] unless node.code && node.source
 
-    code = node.code.sub(/[^\w-]/, '') # remove any punctuation (except dash).
+    code_with_dashes = node.code.gsub(/[^\w-]/, '') # remove any punctuation (except dash).
+    code_without_dashes = code_with_dashes.sub(/-+$/, '') # remove trailing dashes.
     case node.source.code
     when 'marcgac'
-      [Marc::Vocab::GeographicArea.fetch(code)]
+      [Marc::Vocab::GeographicArea.fetch(code_with_dashes, nil) || Marc::Vocab::GeographicArea.fetch(code_without_dashes, nil)].compact
     when 'marccountry'
-      [Marc::Vocab::Country.fetch(code)]
+      [Marc::Vocab::Country.fetch(code_without_dashes, nil)].compact
     else
       []
     end

--- a/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
@@ -296,6 +296,59 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
     end
 
+    context 'when code value from mapped authority - marcgac padded with dashes' do
+      # mapped authorities are marcgac and marccountry
+      # marcgac mapping: https://github.com/sul-dlss/mods/blob/master/lib/mods/marc_geo_area_codes.rb
+      # marccountry mapping: https://github.com/sul-dlss/stanford-mods/blob/master/lib/marc_countries.rb
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          subject: [
+            {
+              code: 'e-ru---',
+              type: 'place',
+              source: {
+                code: 'marcgac'
+              }
+            }
+          ]
+        }
+      end
+
+      it 'maps the code to text' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
+      end
+    end
+
+    context 'when code value from mapped authority - unknown marcgac' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          subject: [
+            {
+              code: 'foo----',
+              type: 'place',
+              source: {
+                code: 'marcgac'
+              }
+            }
+          ]
+        }
+      end
+
+      it 'maps the code to text' do
+        expect(doc).not_to include('sw_subject_geographic_ssim')
+      end
+    end
+
     context 'when code value from mapped authority - marccountry' do
       let(:description) do
         {
@@ -318,6 +371,31 @@ RSpec.describe DescriptiveMetadataIndexer do
 
       it 'maps the code to text' do
         expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
+      end
+    end
+
+    context 'when code value from mapped authority - unknown marccountry' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          subject: [
+            {
+              code: 'fu',
+              type: 'place',
+              source: {
+                code: 'marccountry'
+              }
+            }
+          ]
+        }
+      end
+
+      it 'maps the code to text' do
+        expect(doc).not_to include('sw_subject_geographic_ssim')
       end
     end
 


### PR DESCRIPTION
closes #633

## Why was this change made?
* Handle marcgac that include trailing spaces.
* Don't error when marcgac or country code not found.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


