### PR TITLE
[TEMP, don't merge] temporarily silence honeybadger alert so we don't use quota so fast on stage

### DIFF
--- a/app/services/geographic_builder.rb
+++ b/app/services/geographic_builder.rb
@@ -58,7 +58,9 @@ class GeographicBuilder
       []
     end
   rescue KeyError
-    Honeybadger.notify("[DATA ERROR] Unable to find \"#{code}\" in authority \"#{node.source.code}\"")
+    # TODO: just commented out for now to keep from chewing through HB quota over the weekend since we're hitting
+    # this error a lot on a prior commit where it's uncaught (5297f4fe5c8f7661a5542265a512504efa97e9ea)
+    # Honeybadger.notify("[DATA ERROR] Unable to find \"#{code}\" in authority \"#{node.source.code}\"")
     []
   end
 

--- a/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
@@ -325,8 +325,8 @@ RSpec.describe DescriptiveMetadataIndexer do
 
       it 'maps the code to text' do
         expect(doc).not_to include('sw_subject_geographic_ssim')
-        expect(Honeybadger).to have_received(:notify)
-          .with('[DATA ERROR] Unable to find "e-ru---" in authority "marcgac"')
+        # expect(Honeybadger).to have_received(:notify)
+          # .with('[DATA ERROR] Unable to find "e-ru---" in authority "marcgac"')
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

lots of alerts for unrecognized place code on stage.  since it's just stage, we can take a look monday, without using up lots of our alert quota

https://app.honeybadger.io/projects/49898/faults/79112314
https://app.honeybadger.io/projects/49898/faults/79122054

## How was this change tested?

i just deployed it to stage and the alerts seem to have stopped 🤞 ...

## Which documentation and/or configurations were updated?

n/a