### PR TITLE
Stop using the release tags api

### DIFF
--- a/app/indexers/releasable_indexer.rb
+++ b/app/indexers/releasable_indexer.rb
@@ -3,10 +3,10 @@
 class ReleasableIndexer
   include SolrDocHelper
 
-  attr_reader :id
+  attr_reader :cocina
 
-  def initialize(id:, **)
-    @id = id
+  def initialize(cocina:, **)
+    @cocina = cocina
   end
 
   # @return [Hash] the partial solr document for releasable concerns
@@ -16,8 +16,8 @@ class ReleasableIndexer
 
     # TODO: sort of worried about the performance impact in bulk reindex
     # situations, since released_for recurses all parent collections.  jmartin 2015-07-14
-    released_for.each do |release_target, release_info|
-      add_solr_value(solr_doc, 'released_to', release_target, :symbol, []) if release_info['release']
+    released_for.each do |directive|
+      add_solr_value(solr_doc, 'released_to', directive.to, :symbol, []) if directive.release
     end
 
     # TODO: need to solrize whether item is released to purl?  does released_for return that?
@@ -29,13 +29,6 @@ class ReleasableIndexer
   private
 
   def released_for
-    Rails.logger.debug 'Getting releases'
-    object_client.release_tags.list.tap do
-      Rails.logger.debug 'Got releases'
-    end
-  end
-
-  def object_client
-    Dor::Services::Client.object(id)
+    cocina.administrative.releaseTags
   end
 end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -52,7 +52,6 @@ class Indexer
   FALLBACK_INDEXER = CompositeIndexer.new(
     DataQualityIndexer,
     AdministrativeTagIndexer,
-    ReleasableIndexer,
     WorkflowsIndexer,
     Fedora3LabelIndexer
   )

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Indexer do
         let(:indexer) { described_class.for(model, cocina_with_metadata: Failure(:conversion_error)) }
         let(:model) { Dor::Item.new(pid: druid) }
 
-        it { is_expected.to include('milestones_ssim', 'released_to_ssim', 'wf_ssim', 'tag_ssim', 'obj_label_tesim', 'has_model_ssim', :id) }
+        it { is_expected.to include('milestones_ssim', 'wf_ssim', 'tag_ssim', 'obj_label_tesim', 'has_model_ssim', :id) }
       end
     end
 


### PR DESCRIPTION

## Why was this change made?
We avoid an extra API call to dor-services-app this way since the cocina already has this information

Fixes #642 


## How was this change tested?



## Which documentation and/or configurations were updated?



