### PR TITLE
Temporarily remove HB notification on bad MARCGAC.

### DIFF
--- a/app/services/geographic_builder.rb
+++ b/app/services/geographic_builder.rb
@@ -58,7 +58,8 @@ class GeographicBuilder
       []
     end
   rescue KeyError
-    Honeybadger.notify("[DATA ERROR] Unable to find \"#{code}\" in authority \"#{node.source.code}\"")
+    # Per Arcadia, halt HB notification until after data clean-up.
+    # Honeybadger.notify("[DATA ERROR] Unable to find \"#{code}\" in authority \"#{node.source.code}\"")
     []
   end
 

--- a/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
@@ -325,8 +325,9 @@ RSpec.describe DescriptiveMetadataIndexer do
 
       it 'maps the code to text' do
         expect(doc).not_to include('sw_subject_geographic_ssim')
-        expect(Honeybadger).to have_received(:notify)
-          .with('[DATA ERROR] Unable to find "e-ru---" in authority "marcgac"')
+        # HB notification has been temporarily removed.
+        # expect(Honeybadger).to have_received(:notify)
+        #   .with('[DATA ERROR] Unable to find "e-ru---" in authority "marcgac"')
       end
     end
 


### PR DESCRIPTION
## Why was this change made?
Per @arcadiafalcone, this alert isn't actionable until after MARC record clean-up.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


