### PR TITLE
Protect against versionMetadata not being found

### DIFF
--- a/app/indexers/data_quality_indexer.rb
+++ b/app/indexers/data_quality_indexer.rb
@@ -55,11 +55,14 @@ class DataQualityIndexer
   end
 
   def source_node
-    @source_node ||= identity_metadata.xpath('//identityMetadata/sourceId').first
+    @source_node ||= identity_metadata&.xpath('//identityMetadata/sourceId')&.first
   end
 
   def identity_metadata
-    Nokogiri::XML(resource.datastreams['identityMetadata'].content.body)
+    response = resource.datastreams['identityMetadata'].content
+    return unless response
+
+    Nokogiri::XML(response.body)
   end
 
   def valid_source_id?

--- a/app/indexers/fedora3_label_indexer.rb
+++ b/app/indexers/fedora3_label_indexer.rb
@@ -23,7 +23,10 @@ class Fedora3LabelIndexer
   end
 
   def find_current_version
-    ng_xml = Nokogiri::XML(resource.datastreams['versionMetadata'].content.body)
+    response = resource.datastreams['versionMetadata'].content
+    return unless response # Handle atypical objects like EEMS permission files with no versionMetadata datastream
+
+    ng_xml = Nokogiri::XML(response.body)
     ng_xml.xpath('//versionMetadata/version').map { |node| node['versionId'].to_i }.max
   end
 end


### PR DESCRIPTION
## Why was this change made?
This is a rare occurrence that only occurs on non-cocina compliant objects when they also don't have a versionMetadata datastream.

see https://app.honeybadger.io/projects/49898/faults/79971822



## How was this change tested?



## Which documentation and/or configurations were updated?



