### PR TITLE
Index whether the object is to be migrated or not

### DIFF
--- a/app/indexers/data_quality_indexer.rb
+++ b/app/indexers/data_quality_indexer.rb
@@ -10,8 +10,6 @@ class DataQualityIndexer
   # @return [Hash] the partial solr document for identityMetadata
   def to_solr
     Rails.logger.debug "In #{self.class}"
-    # Filter out Items that were attachments for ETDs/EEMs.  These aren't getting migrated.
-    return {} if filtered_object?
 
     { 'data_quality_ssim' => messages }
   end
@@ -33,9 +31,14 @@ class DataQualityIndexer
   end
 
   def messages
-    [source_id_message].compact.tap do |messages|
+    [source_id_message, migrate_message].compact.tap do |messages|
       messages << 'Cocina conversion failed'
     end
+  end
+
+  # Filter out Items that were attachments for ETDs/EEMs.  These aren't getting migrated.
+  def migrate_message
+    filtered_object? ? 'Do not migrate' : 'To be migrated'
   end
 
   def source_id_message

--- a/spec/indexers/data_quality_indexer_spec.rb
+++ b/spec/indexers/data_quality_indexer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe DataQualityIndexer do
 
     context 'when all fields are present' do
       it 'has none' do
-        expect(doc).to eq('data_quality_ssim' => ['Cocina conversion failed'])
+        expect(doc).to eq('data_quality_ssim' => ['To be migrated', 'Cocina conversion failed'])
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe DataQualityIndexer do
         end
 
         it 'has none' do
-          expect(doc).to eq({})
+          expect(doc).to eq('data_quality_ssim' => ['Do not migrate', 'Cocina conversion failed'])
         end
       end
 
@@ -84,7 +84,7 @@ RSpec.describe DataQualityIndexer do
         let(:model) { 'info:fedora/afmodel:Part' }
 
         it 'has none' do
-          expect(doc).to eq({})
+          expect(doc).to eq('data_quality_ssim' => ['Do not migrate', 'Cocina conversion failed'])
         end
       end
 
@@ -92,7 +92,7 @@ RSpec.describe DataQualityIndexer do
         let(:model) { 'info:fedora/afmodel:PermissionFile' }
 
         it 'has none' do
-          expect(doc).to eq({})
+          expect(doc).to eq('data_quality_ssim' => ['Do not migrate', 'Cocina conversion failed'])
         end
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe DataQualityIndexer do
 
       it 'draws the errors' do
         expect(doc).to eq(
-          'data_quality_ssim' => ['non-comformant sourceId', 'Cocina conversion failed']
+          'data_quality_ssim' => ['non-comformant sourceId', 'To be migrated', 'Cocina conversion failed']
         )
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe DataQualityIndexer do
 
       it 'draws the errors' do
         expect(doc).to eq(
-          'data_quality_ssim' => ['Cocina conversion failed']
+          'data_quality_ssim' => ['To be migrated', 'Cocina conversion failed']
         )
       end
     end


### PR DESCRIPTION


## Why was this change made?

Previously it was hard to find the objects that failed cocina, but we didn't want to migrate them.  Andrew asked for this change.

## How was this change tested?



## Which documentation and/or configurations were updated?



