### PR TITLE
Index objectId_tesim for the FallbackIndexer

### DIFF
--- a/app/indexers/fedora3_label_indexer.rb
+++ b/app/indexers/fedora3_label_indexer.rb
@@ -14,6 +14,8 @@ class Fedora3LabelIndexer
     Rails.logger.debug "In #{self.class}"
     version = find_current_version
     {}.tap do |solr_doc|
+      # Used to search based on druid.
+      solr_doc['objectId_tesim'] = [resource.pid, resource.pid.delete_prefix('druid:')]
       solr_doc['obj_label_tesim'] = resource.label || 'No label provided'
       solr_doc['has_model_ssim'] = resource.models.reject { |model| model == 'info:fedora/fedora-system:FedoraObject-3.0' }
       solr_doc['modified_latest_dttsi'] = resource.lastModifiedDate.to_datetime.utc.strftime('%FT%TZ')

--- a/spec/indexers/fallback_indexer_spec.rb
+++ b/spec/indexers/fallback_indexer_spec.rb
@@ -85,6 +85,9 @@ RSpec.describe FallbackIndexer do
       allow(apo_object_client).to receive_message_chain(:administrative_tags, :list).and_return([])
     end
 
-    it { is_expected.to include('milestones_ssim', 'wf_ssim', 'tag_ssim', 'obj_label_tesim', 'has_model_ssim', :id) }
+    it 'creates the solr document' do
+      expect(solr_doc).to include('milestones_ssim', 'wf_ssim', 'tag_ssim', 'obj_label_tesim', 'has_model_ssim', :id)
+      expect(solr_doc['objectId_tesim']).to eq ['druid:bd999bd9999', 'bd999bd9999']
+    end
   end
 end


### PR DESCRIPTION

## Why was this change made?

When there are are the objects that are unable to cast to cocina, we still need to index the objectId_tesim field (typically indexed in IdentityMetadataIndexer) so you can search for the object by druid in Argo


## How was this change tested?



## Which documentation and/or configurations were updated?



