### PR TITLE
Set the query_hash_key for committee

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,7 +58,8 @@ module DorIndexingApp
                                                                     strict: true,
                                                                     error_class: JSONAPIError,
                                                                     accept_request_filter: accept_proc,
-                                                                    parse_response_by_content_type: false
+                                                                    parse_response_by_content_type: false,
+                                                                    query_hash_key: 'action_dispatch.request.query_parameters'
 
     # TODO: Uncomment when API returns JSON or when Committee allows validating plain-text responses
     #


### PR DESCRIPTION

## Why was this change made?

This avoids a deprecation notice.  Copied from the example at https://github.com/interagent/committee/blob/master/examples/openapi3_rails/config/application.rb#L44


## How was this change tested?



## Which documentation and/or configurations were updated?



