### PR TITLE
Allow app to be accessed in dev env via dor-indexing-app hostname

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,10 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Added in Rails 6. Allows the app when RAILS_ENV=development to be contacted
+  # with a Host header other than `localhost`, `0.0.0.0`, or `::`.
+  config.hosts << ENV.fetch('ALLOWED_DEV_HOSTNAME', 'dor-indexing-app')
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
or whatever ALLOWED_DEV_HOSTNAME is specified in the environment.  

## Why was this change made?

This enables this to be run as a docker container as part of the Argo test suite.


## How was this change tested?



## Which documentation and/or configurations were updated?



