### PR TITLE
Updating to ruby3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@ executors:
     environment:
       IMAGE_NAME: suldlss/dor-indexing-app
     docker:
-    - image: circleci/buildpack-deps:stretch
+    - image: cimg/base
 orbs:
   ruby: circleci/ruby@0.1.2
 
 jobs:
   test:
     docker:
-      - image: circleci/ruby:3.0.3-node
+      - image: cimg/ruby:3.0.3-node
     executor: ruby/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.7-node
+      - image: circleci/ruby:3.0.3-node
     executor: ruby/default
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 config/certs
 config/settings/*.local.yml
 /spec/examples.txt
+
+
+.rbenv-gemsets
+.ruby-version

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,3 @@
 config/certs
 config/settings/*.local.yml
 /spec/examples.txt
-
-
-.rbenv-gemsets
-.ruby-version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
@@ -268,8 +268,6 @@ GEM
     newrelic_rpm (8.2.0)
     nio4r (2.5.8)
     nokogiri (1.13.0-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.0-x86_64-linux)
       racc (~> 1.4)
     okcomputer (1.18.4)
     openapi3_parser (0.9.1)
@@ -414,8 +412,7 @@ GEM
     zeitwerk (2.5.3)
 
 PLATFORMS
-  x86_64-darwin-19
-  x86_64-linux
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
@@ -456,4 +453,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.30
+   2.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.0-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.0-x86_64-linux)
+      racc (~> 1.4)
     okcomputer (1.18.4)
     openapi3_parser (0.9.1)
       commonmarker (~> 0.17)
@@ -413,6 +415,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)

--- a/spec/indexers/collection_title_indexer_spec.rb
+++ b/spec/indexers/collection_title_indexer_spec.rb
@@ -7,21 +7,23 @@ RSpec.describe CollectionTitleIndexer do
   let(:apo_id) { 'druid:bd999bd9999' }
   let(:cocina) do
     Cocina::Models.build(
-      'externalIdentifier' => druid,
-      'type' => Cocina::Models::Vocab.image,
-      'version' => 1,
-      'label' => 'testing',
-      'access' => {},
-      'administrative' => {
-        'hasAdminPolicy' => apo_id
-      },
-      'description' => {
-        'title' => [{ 'value' => 'Test obj' }],
-        'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
-      },
-      'structural' => {
-        'contains' => [],
-        'isMemberOf' => []
+      {
+        'externalIdentifier' => druid,
+        'type' => Cocina::Models::Vocab.image,
+        'version' => 1,
+        'label' => 'testing',
+        'access' => {},
+        'administrative' => {
+          'hasAdminPolicy' => apo_id
+        },
+        'description' => {
+          'title' => [{ 'value' => 'Test obj' }],
+          'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
+        },
+        'structural' => {
+          'contains' => [],
+          'isMemberOf' => []
+        }
       }
     )
   end
@@ -49,17 +51,19 @@ RSpec.describe CollectionTitleIndexer do
 
       let(:collection) do
         Cocina::Models.build(
-          'externalIdentifier' => mock_rel_druid,
-          'type' => Cocina::Models::Vocab.collection,
-          'version' => 1,
-          'label' => 'testing',
-          'administrative' => {
-            'partOfProject' => project,
-            'hasAdminPolicy' => apo_id
-          },
-          'access' => {},
-          'description' => {
-            'title' => [{ 'value' => 'Test object' }]
+          {
+            'externalIdentifier' => mock_rel_druid,
+            'type' => Cocina::Models::Vocab.collection,
+            'version' => 1,
+            'label' => 'testing',
+            'administrative' => {
+              'partOfProject' => project,
+              'hasAdminPolicy' => apo_id
+            },
+            'access' => {},
+            'description' => {
+              'title' => [{ 'value' => 'Test object' }]
+            }
           }
         )
       end

--- a/spec/indexers/composite_indexer_spec.rb
+++ b/spec/indexers/composite_indexer_spec.rb
@@ -9,15 +9,17 @@ RSpec.describe CompositeIndexer do
 
   let(:apo) do
     Cocina::Models.build(
-      'externalIdentifier' => apo_id,
-      'type' => Cocina::Models::Vocab.admin_policy,
-      'version' => 1,
-      'label' => 'testing',
-      'administrative' => {
-        'hasAdminPolicy' => apo_id
-      },
-      'description' => {
-        'title' => [{ 'value' => 'APO title' }]
+      {
+        'externalIdentifier' => apo_id,
+        'type' => Cocina::Models::Vocab.admin_policy,
+        'version' => 1,
+        'label' => 'testing',
+        'administrative' => {
+          'hasAdminPolicy' => apo_id
+        },
+        'description' => {
+          'title' => [{ 'value' => 'APO title' }]
+        }
       }
     )
   end
@@ -31,23 +33,25 @@ RSpec.describe CompositeIndexer do
 
   let(:cocina) do
     Cocina::Models.build(
-      'externalIdentifier' => druid,
-      'type' => Cocina::Models::Vocab.image,
-      'version' => 1,
-      'label' => 'testing',
-      'access' => {},
-      'administrative' => {
-        'hasAdminPolicy' => apo_id
-      },
-      'description' => {
-        'title' => [{ 'value' => 'Test obj' }],
-        'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
-      },
-      'structural' => {
-        'contains' => []
-      },
-      'identification' => {
-        'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '1234' }]
+      {
+        'externalIdentifier' => druid,
+        'type' => Cocina::Models::Vocab.image,
+        'version' => 1,
+        'label' => 'testing',
+        'access' => {},
+        'administrative' => {
+          'hasAdminPolicy' => apo_id
+        },
+        'description' => {
+          'title' => [{ 'value' => 'Test obj' }],
+          'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
+        },
+        'structural' => {
+          'contains' => []
+        },
+        'identification' => {
+          'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '1234' }]
+        }
       }
     )
   end

--- a/spec/indexers/default_object_rights_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_indexer_spec.rb
@@ -5,15 +5,17 @@ require 'rails_helper'
 RSpec.describe DefaultObjectRightsIndexer do
   let(:cocina) do
     Cocina::Models.build(
-      'label' => 'The APO',
-      'version' => 1,
-      'type' => Cocina::Models::Vocab.admin_policy,
-      'externalIdentifier' => 'druid:cb123cd4567',
-      'administrative' => {
-        hasAdminPolicy: 'druid:hv992ry2431',
-        defaultAccess: {
-          useAndReproductionStatement: 'Rights are owned by Stanford University Libraries.',
-          copyright: 'Additional copyright info'
+      {
+        'label' => 'The APO',
+        'version' => 1,
+        'type' => Cocina::Models::Vocab.admin_policy,
+        'externalIdentifier' => 'druid:cb123cd4567',
+        'administrative' => {
+          hasAdminPolicy: 'druid:hv992ry2431',
+          defaultAccess: {
+            useAndReproductionStatement: 'Rights are owned by Stanford University Libraries.',
+            copyright: 'Additional copyright info'
+          }
         }
       }
     )

--- a/spec/indexers/embargo_metadata_indexer_spec.rb
+++ b/spec/indexers/embargo_metadata_indexer_spec.rb
@@ -8,27 +8,29 @@ RSpec.describe EmbargoMetadataIndexer do
   let(:release_date) { '2024-06-06' }
   let(:cocina) do
     Cocina::Models.build(
-      'type' => Cocina::Models::Vocab.object,
-      'externalIdentifier' => druid,
-      'label' => 'testing embargo indexing',
-      'version' => 1,
-      'access' => {
-        'access' => 'world',
-        'download' => 'none',
-        'copyright' => 'some student',
-        'useAndReproductionStatement' => 'restricted until embargo lifted',
-        'embargo' => {
-          'releaseDate' => release_date,
+      {
+        'type' => Cocina::Models::Vocab.object,
+        'externalIdentifier' => druid,
+        'label' => 'testing embargo indexing',
+        'version' => 1,
+        'access' => {
           'access' => 'world',
-          'download' => 'world',
-          'useAndReproductionStatement' => 'freedom reigns'
+          'download' => 'none',
+          'copyright' => 'some student',
+          'useAndReproductionStatement' => 'restricted until embargo lifted',
+          'embargo' => {
+            'releaseDate' => release_date,
+            'access' => 'world',
+            'download' => 'world',
+            'useAndReproductionStatement' => 'freedom reigns'
+          }
+        },
+        'administrative' => {
+          'hasAdminPolicy' => apo_id
+        },
+        'description' => {
+          'title' => [{ 'value' => 'embargo indexing object' }]
         }
-      },
-      'administrative' => {
-        'hasAdminPolicy' => apo_id
-      },
-      'description' => {
-        'title' => [{ 'value' => 'embargo indexing object' }]
       }
     )
   end
@@ -61,21 +63,23 @@ RSpec.describe EmbargoMetadataIndexer do
     context 'when there is no embargo' do
       let(:cocina) do
         Cocina::Models.build(
-          'type' => Cocina::Models::Vocab.object,
-          'externalIdentifier' => druid,
-          'label' => 'testing embargo indexing',
-          'version' => 1,
-          'access' => {
-            'access' => 'world',
-            'download' => 'none',
-            'copyright' => 'some student',
-            'useAndReproductionStatement' => 'restricted until embargo lifted'
-          },
-          'administrative' => {
-            'hasAdminPolicy' => apo_id
-          },
-          'description' => {
-            'title' => [{ 'value' => 'embargo indexing object' }]
+          {
+            'type' => Cocina::Models::Vocab.object,
+            'externalIdentifier' => druid,
+            'label' => 'testing embargo indexing',
+            'version' => 1,
+            'access' => {
+              'access' => 'world',
+              'download' => 'none',
+              'copyright' => 'some student',
+              'useAndReproductionStatement' => 'restricted until embargo lifted'
+            },
+            'administrative' => {
+              'hasAdminPolicy' => apo_id
+            },
+            'description' => {
+              'title' => [{ 'value' => 'embargo indexing object' }]
+            }
           }
         )
       end

--- a/spec/indexers/identifiable_indexer_spec.rb
+++ b/spec/indexers/identifiable_indexer_spec.rb
@@ -7,23 +7,25 @@ RSpec.describe IdentifiableIndexer do
   let(:apo_id) { 'druid:bd999bd9999' }
   let(:cocina) do
     Cocina::Models.build(
-      'externalIdentifier' => druid,
-      'type' => Cocina::Models::Vocab.image,
-      'version' => 1,
-      'label' => 'testing',
-      'access' => {},
-      'administrative' => {
-        'hasAdminPolicy' => apo_id
-      },
-      'description' => {
-        'title' => [{ 'value' => 'Test obj' }],
-        'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
-      },
-      'structural' => {
-        'contains' => [],
-        'isMemberOf' => []
-      },
-      'identification' => identification
+      {
+        'externalIdentifier' => druid,
+        'type' => Cocina::Models::Vocab.image,
+        'version' => 1,
+        'label' => 'testing',
+        'access' => {},
+        'administrative' => {
+          'hasAdminPolicy' => apo_id
+        },
+        'description' => {
+          'title' => [{ 'value' => 'Test obj' }],
+          'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
+        },
+        'structural' => {
+          'contains' => [],
+          'isMemberOf' => []
+        },
+        'identification' => identification
+      }
     )
   end
   let(:identification) do
@@ -52,15 +54,17 @@ RSpec.describe IdentifiableIndexer do
 
     let(:related) do
       Cocina::Models.build(
-        'externalIdentifier' => apo_id,
-        'type' => Cocina::Models::Vocab.admin_policy,
-        'version' => 1,
-        'label' => 'testing',
-        'administrative' => {
-          'hasAdminPolicy' => apo_id
-        },
-        'description' => {
-          'title' => [{ 'value' => 'Test object' }]
+        {
+          'externalIdentifier' => apo_id,
+          'type' => Cocina::Models::Vocab.admin_policy,
+          'version' => 1,
+          'label' => 'testing',
+          'administrative' => {
+            'hasAdminPolicy' => apo_id
+          },
+          'description' => {
+            'title' => [{ 'value' => 'Test object' }]
+          }
         }
       )
     end
@@ -90,17 +94,19 @@ RSpec.describe IdentifiableIndexer do
 
       let(:related) do
         Cocina::Models.build(
-          'externalIdentifier' => mock_rel_druid,
-          'type' => Cocina::Models::Vocab.collection,
-          'version' => 1,
-          'label' => 'testing',
-          'administrative' => {
-            'partOfProject' => project,
-            'hasAdminPolicy' => apo_id
-          },
-          'access' => {},
-          'description' => {
-            'title' => [{ 'value' => 'Test object' }]
+          {
+            'externalIdentifier' => mock_rel_druid,
+            'type' => Cocina::Models::Vocab.collection,
+            'version' => 1,
+            'label' => 'testing',
+            'administrative' => {
+              'partOfProject' => project,
+              'hasAdminPolicy' => apo_id
+            },
+            'access' => {},
+            'description' => {
+              'title' => [{ 'value' => 'Test object' }]
+            }
           }
         )
       end
@@ -126,19 +132,21 @@ RSpec.describe IdentifiableIndexer do
     context 'with no identification sub-schema' do
       let(:cocina) do
         Cocina::Models.build(
-          'externalIdentifier' => druid,
-          'type' => Cocina::Models::Vocab.image,
-          'version' => 1,
-          'label' => 'testing',
-          'access' => {},
-          'administrative' => {
-            'hasAdminPolicy' => apo_id
-          },
-          'description' => {
-            'title' => [{ 'value' => 'Test obj' }],
-            'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
-          },
-          'structural' => {}
+          {
+            'externalIdentifier' => druid,
+            'type' => Cocina::Models::Vocab.image,
+            'version' => 1,
+            'label' => 'testing',
+            'access' => {},
+            'administrative' => {
+              'hasAdminPolicy' => apo_id
+            },
+            'description' => {
+              'title' => [{ 'value' => 'Test obj' }],
+              'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
+            },
+            'structural' => {}
+          }
         )
       end
 

--- a/spec/indexers/releasable_indexer_spec.rb
+++ b/spec/indexers/releasable_indexer_spec.rb
@@ -7,18 +7,20 @@ RSpec.describe ReleasableIndexer do
 
   let(:cocina) do
     Cocina::Models.build(
-      'externalIdentifier' => 'druid:pz263ny9658',
-      'type' => Cocina::Models::Vocab.image,
-      'version' => 1,
-      'label' => 'testing',
-      'access' => {},
-      'administrative' => administrative,
-      'description' => {
-        'title' => [{ 'value' => 'Test obj' }]
-      },
-      'structural' => {},
-      'identification' => {
-        'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '1234' }]
+      {
+        'externalIdentifier' => 'druid:pz263ny9658',
+        'type' => Cocina::Models::Vocab.image,
+        'version' => 1,
+        'label' => 'testing',
+        'access' => {},
+        'administrative' => administrative,
+        'description' => {
+          'title' => [{ 'value' => 'Test obj' }]
+        },
+        'structural' => {},
+        'identification' => {
+          'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '1234' }]
+        }
       }
     )
   end

--- a/spec/indexers/rights_metadata_indexer_spec.rb
+++ b/spec/indexers/rights_metadata_indexer_spec.rb
@@ -21,16 +21,18 @@ RSpec.describe RightsMetadataIndexer do
     end
     let(:cocina) do
       Cocina::Models.build(
-        'externalIdentifier' => 'druid:rt923jk3429',
-        'type' => Cocina::Models::Vocab.collection,
-        'version' => 1,
-        'label' => 'testing',
-        'access' => access,
-        'administrative' => {
-          'hasAdminPolicy' => 'druid:xx000xx0000'
-        },
-        'description' => {
-          'title' => [{ 'value' => 'Test obj' }]
+        {
+          'externalIdentifier' => 'druid:rt923jk3429',
+          'type' => Cocina::Models::Vocab.collection,
+          'version' => 1,
+          'label' => 'testing',
+          'access' => access,
+          'administrative' => {
+            'hasAdminPolicy' => 'druid:xx000xx0000'
+          },
+          'description' => {
+            'title' => [{ 'value' => 'Test obj' }]
+          }
         }
       )
     end
@@ -48,18 +50,20 @@ RSpec.describe RightsMetadataIndexer do
   context 'with an item' do
     let(:cocina) do
       Cocina::Models.build(
-        'externalIdentifier' => 'druid:rt923jk3429',
-        'type' => Cocina::Models::Vocab.image,
-        'version' => 1,
-        'label' => 'testing',
-        'access' => access,
-        'administrative' => {
-          'hasAdminPolicy' => 'druid:xx000xx0000'
-        },
-        'description' => {
-          'title' => [{ 'value' => 'Test obj' }]
-        },
-        'structural' => structural
+        {
+          'externalIdentifier' => 'druid:rt923jk3429',
+          'type' => Cocina::Models::Vocab.image,
+          'version' => 1,
+          'label' => 'testing',
+          'access' => access,
+          'administrative' => {
+            'hasAdminPolicy' => 'druid:xx000xx0000'
+          },
+          'description' => {
+            'title' => [{ 'value' => 'Test obj' }]
+          },
+          'structural' => structural
+        }
       )
     end
     let(:structural) { {} }

--- a/spec/indexers/role_metadata_indexer_spec.rb
+++ b/spec/indexers/role_metadata_indexer_spec.rb
@@ -6,32 +6,34 @@ RSpec.describe RoleMetadataIndexer do
   let(:apo_id) { 'druid:gf999hb9999' }
   let(:cocina) do
     Cocina::Models.build(
-      'externalIdentifier' => apo_id,
-      'type' => Cocina::Models::Vocab.admin_policy,
-      'version' => 1,
-      'label' => 'testing',
-      'administrative' => {
-        'hasAdminPolicy' => apo_id,
-        'roles' => [
-          { 'name' => 'dor-apo-manager',
-            'members' => [
-              {
-                'type' => 'workgroup',
-                'identifier' => 'dlss:dor-admin'
-              },
-              {
-                'type' => 'workgroup',
-                'identifier' => 'sdr:developer'
-              },
-              {
-                'type' => 'sunetid',
-                'identifier' => 'tcramer'
-              }
-            ] }
-        ]
-      },
-      'description' => {
-        'title' => [{ 'value' => 'APO title' }]
+      {
+        'externalIdentifier' => apo_id,
+        'type' => Cocina::Models::Vocab.admin_policy,
+        'version' => 1,
+        'label' => 'testing',
+        'administrative' => {
+          'hasAdminPolicy' => apo_id,
+          'roles' => [
+            { 'name' => 'dor-apo-manager',
+              'members' => [
+                {
+                  'type' => 'workgroup',
+                  'identifier' => 'dlss:dor-admin'
+                },
+                {
+                  'type' => 'workgroup',
+                  'identifier' => 'sdr:developer'
+                },
+                {
+                  'type' => 'sunetid',
+                  'identifier' => 'tcramer'
+                }
+              ] }
+          ]
+        },
+        'description' => {
+          'title' => [{ 'value' => 'APO title' }]
+        }
       }
     )
   end

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -27,17 +27,19 @@ RSpec.describe Indexer do
   context 'when the model is an item' do
     let(:cocina) do
       Cocina::Models.build(
-        'type' => Cocina::Models::Vocab.object,
-        'structural' => {
-          isMemberOf: collections
-        },
-        'label' => 'Test DRO',
-        'version' => 1,
-        'administrative' => {
-          hasAdminPolicy: 'druid:gf999hb9999'
-        },
-        'access' => {},
-        'externalIdentifier' => druid
+        {
+          'type' => Cocina::Models::Vocab.object,
+          'structural' => {
+            isMemberOf: collections
+          },
+          'label' => 'Test DRO',
+          'version' => 1,
+          'administrative' => {
+            hasAdminPolicy: 'druid:gf999hb9999'
+          },
+          'access' => {},
+          'externalIdentifier' => druid
+        }
       )
     end
 
@@ -53,16 +55,18 @@ RSpec.describe Indexer do
       end
       let(:related) do
         Cocina::Models.build(
-          'externalIdentifier' => 'druid:bc999df2323',
-          'type' => Cocina::Models::Vocab.collection,
-          'version' => 1,
-          'label' => 'testing',
-          'administrative' => {
-            'hasAdminPolicy' => 'druid:gf999hb9999'
-          },
-          'access' => {},
-          'description' => {
-            'title' => [{ 'value' => 'Test object' }]
+          {
+            'externalIdentifier' => 'druid:bc999df2323',
+            'type' => Cocina::Models::Vocab.collection,
+            'version' => 1,
+            'label' => 'testing',
+            'administrative' => {
+              'hasAdminPolicy' => 'druid:gf999hb9999'
+            },
+            'access' => {},
+            'description' => {
+              'title' => [{ 'value' => 'Test object' }]
+            }
           }
         )
       end
@@ -94,13 +98,15 @@ RSpec.describe Indexer do
   context 'when the model is an admin policy' do
     let(:cocina) do
       Cocina::Models.build(
-        'type' => Cocina::Models::Vocab.admin_policy,
-        'label' => 'Test APO',
-        'version' => 1,
-        'administrative' => {
-          hasAdminPolicy: 'druid:gf999hb9999'
-        },
-        'externalIdentifier' => druid
+        {
+          'type' => Cocina::Models::Vocab.admin_policy,
+          'label' => 'Test APO',
+          'version' => 1,
+          'administrative' => {
+            hasAdminPolicy: 'druid:gf999hb9999'
+          },
+          'externalIdentifier' => druid
+        }
       )
     end
 
@@ -110,14 +116,16 @@ RSpec.describe Indexer do
   context 'when the model is a collection' do
     let(:cocina) do
       Cocina::Models.build(
-        'type' => Cocina::Models::Vocab.collection,
-        'label' => 'Test Collection',
-        'version' => 1,
-        'administrative' => {
-          hasAdminPolicy: 'druid:gf999hb9999'
-        },
-        'access' => {},
-        'externalIdentifier' => druid
+        {
+          'type' => Cocina::Models::Vocab.collection,
+          'label' => 'Test Collection',
+          'version' => 1,
+          'administrative' => {
+            hasAdminPolicy: 'druid:gf999hb9999'
+          },
+          'access' => {},
+          'externalIdentifier' => druid
+        }
       )
     end
 
@@ -127,15 +135,17 @@ RSpec.describe Indexer do
   context 'when the model is an agreement' do
     let(:cocina) do
       Cocina::Models.build(
-        'type' => Cocina::Models::Vocab.agreement,
-        'structural' => {},
-        'label' => 'Test Agreement',
-        'version' => 1,
-        'administrative' => {
-          hasAdminPolicy: 'druid:gf999hb9999'
-        },
-        'access' => {},
-        'externalIdentifier' => druid
+        {
+          'type' => Cocina::Models::Vocab.agreement,
+          'structural' => {},
+          'label' => 'Test Agreement',
+          'version' => 1,
+          'administrative' => {
+            hasAdminPolicy: 'druid:gf999hb9999'
+          },
+          'access' => {},
+          'externalIdentifier' => druid
+        }
       )
     end
 
@@ -149,15 +159,17 @@ RSpec.describe Indexer do
 
     let(:apo) do
       Cocina::Models.build(
-        'externalIdentifier' => apo_id,
-        'type' => Cocina::Models::Vocab.admin_policy,
-        'version' => 1,
-        'label' => 'testing',
-        'administrative' => {
-          'hasAdminPolicy' => 'druid:xx000xx0000'
-        },
-        'description' => {
-          'title' => [{ 'value' => 'APO title' }]
+        {
+          'externalIdentifier' => apo_id,
+          'type' => Cocina::Models::Vocab.admin_policy,
+          'version' => 1,
+          'label' => 'testing',
+          'administrative' => {
+            'hasAdminPolicy' => 'druid:xx000xx0000'
+          },
+          'description' => {
+            'title' => [{ 'value' => 'APO title' }]
+          }
         }
       )
     end
@@ -172,58 +184,60 @@ RSpec.describe Indexer do
     context 'when the model is an item' do
       let(:cocina) do
         Cocina::Models.build(
-          'externalIdentifier' => druid,
-          'type' => Cocina::Models::Vocab.image,
-          'version' => 1,
-          'label' => 'testing',
-          'access' => {},
-          'administrative' => {
-            'hasAdminPolicy' => apo_id
-          },
-          'description' => {
-            'title' => [{ 'value' => 'Test obj' }],
-            'subject' => [{ 'type' => 'topic', 'value' => 'word' }],
-            'event' => [
-              {
-                'type' => 'creation',
-                'date' => [
-                  {
-                    'value' => '2021-01-01',
-                    'status' => 'primary',
-                    'encoding' => {
-                      'code' => 'w3cdtf'
-                    },
-                    'type' => 'creation'
-                  }
-                ]
-              },
-              {
-                'type' => 'publication',
-                'location' => [
-                  {
-                    'value' => 'Moskva'
-                  }
-                ],
-                'contributor' => [
-                  {
-                    'name' => [
-                      {
-                        'value' => 'Izdatelʹstvo "Vesʹ Mir"'
-                      }
-                    ],
-                    'type' => 'organization',
-                    'role' => [{ 'value' => 'publisher' }]
-                  }
-                ]
-              }
-            ]
-          },
-          'structural' => {
-            'contains' => [],
-            'isMemberOf' => []
-          },
-          'identification' => {
-            'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '1234' }]
+          {
+            'externalIdentifier' => druid,
+            'type' => Cocina::Models::Vocab.image,
+            'version' => 1,
+            'label' => 'testing',
+            'access' => {},
+            'administrative' => {
+              'hasAdminPolicy' => apo_id
+            },
+            'description' => {
+              'title' => [{ 'value' => 'Test obj' }],
+              'subject' => [{ 'type' => 'topic', 'value' => 'word' }],
+              'event' => [
+                {
+                  'type' => 'creation',
+                  'date' => [
+                    {
+                      'value' => '2021-01-01',
+                      'status' => 'primary',
+                      'encoding' => {
+                        'code' => 'w3cdtf'
+                      },
+                      'type' => 'creation'
+                    }
+                  ]
+                },
+                {
+                  'type' => 'publication',
+                  'location' => [
+                    {
+                      'value' => 'Moskva'
+                    }
+                  ],
+                  'contributor' => [
+                    {
+                      'name' => [
+                        {
+                          'value' => 'Izdatelʹstvo "Vesʹ Mir"'
+                        }
+                      ],
+                      'type' => 'organization',
+                      'role' => [{ 'value' => 'publisher' }]
+                    }
+                  ]
+                }
+              ]
+            },
+            'structural' => {
+              'contains' => [],
+              'isMemberOf' => []
+            },
+            'identification' => {
+              'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '1234' }]
+            }
           }
         )
       end
@@ -242,16 +256,18 @@ RSpec.describe Indexer do
 
       let(:cocina) do
         Cocina::Models.build(
-          'externalIdentifier' => druid,
-          'type' => Cocina::Models::Vocab.admin_policy,
-          'version' => 1,
-          'label' => 'testing',
-          'administrative' => {
-            'hasAdminPolicy' => apo_id,
-            'defaultObjectRights' => '<rightsMetadata/>'
-          },
-          'description' => {
-            'title' => [{ 'value' => 'Test obj' }]
+          {
+            'externalIdentifier' => druid,
+            'type' => Cocina::Models::Vocab.admin_policy,
+            'version' => 1,
+            'label' => 'testing',
+            'administrative' => {
+              'hasAdminPolicy' => apo_id,
+              'defaultObjectRights' => '<rightsMetadata/>'
+            },
+            'description' => {
+              'title' => [{ 'value' => 'Test obj' }]
+            }
           }
         )
       end
@@ -264,16 +280,18 @@ RSpec.describe Indexer do
 
       let(:cocina) do
         Cocina::Models.build(
-          'externalIdentifier' => druid,
-          'type' => Cocina::Models::Vocab.admin_policy,
-          'version' => 1,
-          'label' => 'testing',
-          'administrative' => {
-            'hasAdminPolicy' => apo_id,
-            'defaultObjectRights' => '<rightsMetadata/>'
-          },
-          'description' => {
-            'title' => [{ 'value' => 'Test obj' }]
+          {
+            'externalIdentifier' => druid,
+            'type' => Cocina::Models::Vocab.admin_policy,
+            'version' => 1,
+            'label' => 'testing',
+            'administrative' => {
+              'hasAdminPolicy' => apo_id,
+              'defaultObjectRights' => '<rightsMetadata/>'
+            },
+            'description' => {
+              'title' => [{ 'value' => 'Test obj' }]
+            }
           }
         )
       end


### PR DESCRIPTION
## Why was this change made?

ruby3.0 techstack upgrades

## How was this change tested?

Ran tests locally under ruby v2.7.5 and ruby v3.0.3. The build passed in [CircleCI](https://app.circleci.com/pipelines/github/sul-dlss/dor_indexing_app/386/workflows/bb103167-a4a3-463b-98a2-7b1ef0beafc2/jobs/623).

## Which documentation and/or configurations were updated?




