### PR TITLE
use new object metadata object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'rubydora'
 gem 'solrizer'
 
 # DLSS gems
-gem 'dor-services-client', '~> 7.0'
+gem 'dor-services-client', '~> 7.9'
 gem 'dor-workflow-client', '~> 3.20'
 gem 'parse_date'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services-client (7.8.0)
+    dor-services-client (7.9.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.64.0)
       deprecation
@@ -432,7 +432,7 @@ DEPENDENCIES
   committee
   config
   dlss-capistrano (~> 3.11)
-  dor-services-client (~> 7.0)
+  dor-services-client (~> 7.9)
   dor-workflow-client (~> 3.20)
   dry-monads (~> 1.3)
   erubis

--- a/spec/indexers/data_indexer_spec.rb
+++ b/spec/indexers/data_indexer_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe DataIndexer do
 
   describe '#to_solr' do
     let(:metadata) do
-      { 'Last-Modified' => 'Thu, 04 Mar 2021 23:05:34 GMT',
-        'X-Created-At' => 'Wed, 01 Jan 2020 12:00:01 GMT' }
+      instance_double(Dor::Services::Client::ObjectMetadata,
+                      updated_at: 'Thu, 04 Mar 2021 23:05:34 GMT',
+                      created_at: 'Wed, 01 Jan 2020 12:00:01 GMT')
     end
     let(:indexer) do
       CompositeIndexer.new(

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Indexer do
   subject(:indexer) { described_class.for(model: cocina, metadata: metadata) }
 
   let(:metadata) do
-    { 'Last-Modified' => 'Thu, 04 Mar 2021 23:05:34 GMT',
-      'X-Created-At' => 'Wed, 01 Jan 2020 12:00:01 GMT' }
+    instance_double(Dor::Services::Client::ObjectMetadata,
+                    updated_at: 'Thu, 04 Mar 2021 23:05:34 GMT',
+                    created_at: 'Wed, 01 Jan 2020 12:00:01 GMT')
   end
   let(:druid) { 'druid:xx999xx9999' }
   let(:releasable) do


### PR DESCRIPTION
## Why was this change made?

* Update dor-services-client
* Revert temporary fixes to  indexing based on new created_at header
* Retrieve created_at dates from latest version of dor-services-client

## How was this change tested?

Updated tests

## Which documentation and/or configurations were updated?



