### PR TITLE
Index without lookup

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -3,8 +3,12 @@
 # Main controller of application
 class DorController < ApplicationController
   def reindex
-    indexer = Indexer.new(solr: solr)
-    @solr_doc = indexer.reindex_pid params[:pid], add_attributes: { commitWithin: params.fetch(:commitWithin, 1000).to_i }
+    indexer = Indexer.new(solr: solr, pid: params[:pid])
+    cocina_with_metadata = indexer.fetch_model_with_metadata
+    @solr_doc = indexer.reindex_pid(
+      add_attributes: { commitWithin: params.fetch(:commitWithin, 1000).to_i },
+      cocina_with_metadata: cocina_with_metadata
+    )
     indexer.commit unless params[:commitWithin] # reindex_pid doesn't commit, but callers of this method may expect the update to be committed immediately
     render status: :ok, plain: "Successfully updated index for #{params[:pid]}"
   rescue Dor::Services::Client::NotFoundResponse, Rubydora::RecordNotFound

--- a/app/jobs/reindex_by_druid_job.rb
+++ b/app/jobs/reindex_by_druid_job.rb
@@ -12,8 +12,12 @@ class ReindexByDruidJob
     druid = druid_from_message(msg)
     # Since we don't have the metadata (namely created_at) in the message,
     # we need another API call. :(
-    indexer = Indexer.new(solr: solr)
-    indexer.reindex_pid druid, add_attributes: { commitWithin: 1000 }
+    indexer = Indexer.new(solr: solr, pid: druid)
+    cocina_with_metadata = indexer.fetch_model_with_metadata
+    indexer.reindex_pid(
+      add_attributes: { commitWithin: 1000 },
+      cocina_with_metadata: cocina_with_metadata
+    )
     ack!
   end
 

--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -12,8 +12,12 @@ class ReindexJob
     model = build_cocina_model_from_json_str(msg)
     # Since we don't have the metadata (namely created_at) in the message,
     # we need another API call. :(
-    indexer = Indexer.new(solr: solr)
-    indexer.reindex_pid model.externalIdentifier, add_attributes: { commitWithin: 1000 }
+    indexer = Indexer.new(solr: solr, pid: model.externalIdentifier)
+    cocina_with_metadata = indexer.fetch_model_with_metadata
+    indexer.reindex_pid(
+      add_attributes: { commitWithin: 1000 },
+      cocina_with_metadata: cocina_with_metadata
+    )
     ack!
   end
 

--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -3,17 +3,17 @@
 # Reindexes an object
 class ReindexJob
   include Sneakers::Worker
+  include Dry::Monads[:result]
+
   # This worker will connect to "dor.indexing-with-model" queue
   # env is set to nil since by default the actual queue name would be
   # "dor.indexing-with-model_development"
   from_queue 'dor.indexing-with-model', env: nil
 
   def work(msg)
-    model = build_cocina_model_from_json_str(msg)
-    # Since we don't have the metadata (namely created_at) in the message,
-    # we need another API call. :(
-    indexer = Indexer.new(solr: solr, pid: model.externalIdentifier)
-    cocina_with_metadata = indexer.fetch_model_with_metadata
+    cocina_with_metadata = build_cocina_model_from_json_str(msg)
+    pid = cocina_with_metadata.value!.first.externalIdentifier
+    indexer = Indexer.new(solr: solr, pid: pid)
     indexer.reindex_pid(
       add_attributes: { commitWithin: 1000 },
       cocina_with_metadata: cocina_with_metadata
@@ -27,6 +27,10 @@ class ReindexJob
 
   def build_cocina_model_from_json_str(str)
     json = JSON.parse(str)
-    Cocina::Models.build(json.fetch('model'))
+    model = Cocina::Models.build(json.fetch('model'))
+
+    metadata = Dor::Services::Client::ObjectMetadata.new(updated_at: json.fetch('modified_at'),
+                                                         created_at: json.fetch('created_at'))
+    Success([model, metadata])
   end
 end

--- a/spec/jobs/reindex_by_druid_job_spec.rb
+++ b/spec/jobs/reindex_by_druid_job_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe ReindexByDruidJob do
   let(:message) { { druid: druid }.to_json }
   let(:druid) { 'druid:bc123df4567' }
-  let(:indexer) { instance_double(Indexer, reindex_pid: true) }
+  let(:result) { Success(double) }
+  let(:indexer) { instance_double(Indexer, reindex_pid: true, fetch_model_with_metadata: result) }
 
   before do
     allow(Indexer).to receive(:new).and_return(indexer)
@@ -13,6 +14,7 @@ RSpec.describe ReindexByDruidJob do
 
   it 'updates the druid' do
     described_class.new.work(message)
-    expect(indexer).to have_received(:reindex_pid).with(druid, add_attributes: { commitWithin: 1000 })
+    expect(indexer).to have_received(:reindex_pid)
+      .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: result)
   end
 end

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe ReindexJob do
                             administrative: { hasAdminPolicy: 'druid:xx999xx9999' })
   end
 
-  let(:indexer) { instance_double(Indexer, reindex_pid: true) }
+  let(:result) { Success(double) }
+  let(:indexer) { instance_double(Indexer, reindex_pid: true, fetch_model_with_metadata: result) }
 
   before do
     allow(Indexer).to receive(:new).and_return(indexer)
@@ -23,6 +24,7 @@ RSpec.describe ReindexJob do
 
   it 'updates the druid' do
     described_class.new.work(message)
-    expect(indexer).to have_received(:reindex_pid).with(druid, add_attributes: { commitWithin: 1000 })
+    expect(indexer).to have_received(:reindex_pid)
+      .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: result)
   end
 end

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ReindexJob do
-  let(:message) { { model: model }.to_json }
+  let(:message) { { model: model, created_at: 'Wed, 01 Jan 2021 12:58:00 GMT', modified_at: 'Wed, 03 Mar 2021 18:58:00 GMT' }.to_json }
   let(:druid) { 'druid:bc123df4567' }
 
   let(:model) do
@@ -16,7 +16,7 @@ RSpec.describe ReindexJob do
   end
 
   let(:result) { Success(double) }
-  let(:indexer) { instance_double(Indexer, reindex_pid: true, fetch_model_with_metadata: result) }
+  let(:indexer) { instance_double(Indexer, reindex_pid: true) }
 
   before do
     allow(Indexer).to receive(:new).and_return(indexer)
@@ -25,6 +25,6 @@ RSpec.describe ReindexJob do
   it 'updates the druid' do
     described_class.new.work(message)
     expect(indexer).to have_received(:reindex_pid)
-      .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: result)
+      .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: Success(Array))
   end
 end


### PR DESCRIPTION
## Why was this change made?

This allows us to index documents that come over RabbitMQ rather than having to do another API call to DSA when a message was received. This is enabled by https://github.com/sul-dlss/dor-services-app/pull/3312

## How was this change tested?



## Which documentation and/or configurations were updated?



