### PR TITLE
[SPIKE] Index virtual objects as both items and virtual objects

### DIFF
--- a/spec/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_indexer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe IdentityMetadataIndexer do
-  let(:cocina) do
+  let(:cocina_object) do
     Cocina::Models.build({
       externalIdentifier: 'druid:rt923jk3421',
       type: type,
@@ -18,7 +18,7 @@ RSpec.describe IdentityMetadataIndexer do
   end
 
   let(:indexer) do
-    described_class.new(cocina: cocina)
+    described_class.new(cocina: cocina_object)
   end
 
   describe '#to_solr' do
@@ -49,6 +49,58 @@ RSpec.describe IdentityMetadataIndexer do
           'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                                  'catkey:129483625'],
           'objectType_ssim' => ['item'],
+          'source_id_ssim' => ['google:STANFORD_342837261527']
+        )
+      end
+    end
+
+    context 'with a virtual object' do
+      let(:cocina_object) do
+        Cocina::Models.build({
+          externalIdentifier: 'druid:rt923jk3421',
+          type: type,
+          version: 1,
+          label: 'Squirrels of North America',
+          access: {},
+          administrative: {
+            hasAdminPolicy: 'druid:bd999bd9999'
+          },
+          identification: identification,
+          structural: {
+            hasMemberOrders: [
+              {
+                members: [
+                  'druid:bj875kg9558'
+                ]
+              }
+            ]
+          }
+        }.with_indifferent_access)
+      end
+      let(:type) { Cocina::Models::Vocab.book }
+      let(:identification) do
+        {
+          sourceId: 'google:STANFORD_342837261527',
+          catalogLinks: [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '129483625'
+            }
+          ],
+          barcode: '36105049267078'
+        }
+      end
+
+      it 'has the fields used by argo' do
+        expect(doc).to include(
+          'barcode_id_ssim' => ['36105049267078'],
+          'catkey_id_ssim' => ['129483625'],
+          'dor_id_tesim' => %w[STANFORD_342837261527 36105049267078 129483625],
+          'identifier_ssim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
+                                'catkey:129483625'],
+          'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
+                                 'catkey:129483625'],
+          'objectType_ssim' => %w[item virtualObject],
           'source_id_ssim' => ['google:STANFORD_342837261527']
         )
       end


### PR DESCRIPTION
## Why was this change made?

This would make it easier for Argo users to find and operate in bulk on virtual objects. Whether it is valuable, or has other risks or side effects, would be worth discussing. I could also be convinced that we could/should use the existing has_constituents_ssim field for this somehow?


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None
