### PR TITLE
Consume delete messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is going to create queues for this application that bind to some topics.
 ## RabbitMQ queue workers
 In a development environment you can start sneakers this way:
 ```sh
-WORKERS=ReindexJob,ReindexByDruidJob bin/rake sneakers:run
+WORKERS=ReindexJob,ReindexByDruidJob,DeleteByDruidJob bin/rake sneakers:run
 ```
 
 but on the production machines we use systemd to do the same:

--- a/app/jobs/delete_by_druid_job.rb
+++ b/app/jobs/delete_by_druid_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Deletes an index entry given a druid
+class DeleteByDruidJob
+  include Sneakers::Worker
+
+  # This worker will connect to "dor.deleting-by-druid" queue
+  # env is set to nil since by default the actual queue name would be
+  # "dor.deleting-by-druid_development"
+  from_queue 'dor.deleting-by-druid', env: nil
+
+  def work(msg)
+    druid = druid_from_message(msg)
+
+    solr.delete_by_id(druid, commitWithin: 1000)
+    solr.commit
+
+    ack!
+  end
+
+  def solr
+    RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
+  end
+
+  def druid_from_message(str)
+    JSON.parse(str).fetch('druid')
+  end
+end

--- a/lib/tasks/rabbitmq.rake
+++ b/lib/tasks/rabbitmq.rake
@@ -27,6 +27,12 @@ namespace :rabbitmq do
     queue = channel.queue('dor.indexing-with-model', durable: true)
     queue.bind(update_exchange, routing_key: '#')
     queue.bind(create_exchange, routing_key: '#')
+
+    # These messages look like this: { druid: 'druid:bc123kh8976', deleted_at: 'timestamp here' }
+    delete_exchange = channel.topic('sdr.objects.deleted')
+    queue = channel.queue('dor.deleting-by-druid', durable: true)
+    queue.bind(delete_exchange, routing_key: '#')
+
     conn.close
   end
 end

--- a/spec/jobs/delete_by_druid_job_spec.rb
+++ b/spec/jobs/delete_by_druid_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeleteByDruidJob do
+  let(:message) { { druid: druid, deleted_at: Time.zone.now }.to_json }
+  let(:druid) { 'druid:bc123df4567' }
+  let(:mock_solr) { instance_double(RSolr::Client, delete_by_id: true, commit: true) }
+
+  before do
+    allow(RSolr).to receive(:connect).and_return(mock_solr)
+  end
+
+  it 'updates the druid' do
+    described_class.new.work(message)
+    expect(mock_solr).to have_received(:delete_by_id).with(druid, commitWithin: 1000).once
+    expect(mock_solr).to have_received(:commit).once
+  end
+end


### PR DESCRIPTION
Fixes #740

## Why was this change made?

Remove the index entry from Solr for a given druid.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None
