### PR TITLE
index rights for APOs

### DIFF
--- a/app/indexers/default_object_rights_indexer.rb
+++ b/app/indexers/default_object_rights_indexer.rb
@@ -13,7 +13,9 @@ class DefaultObjectRightsIndexer
 
     {
       'use_statement_ssim' => use_statement,
-      'copyright_ssim' => copyright
+      'copyright_ssim' => copyright,
+      'rights_descriptions_ssim' => 'Dark',
+      'default_rights_descriptions_ssim' => RightsDescriptionBuilder.build(cocina)
     }
   end
 

--- a/app/indexers/rights_metadata_indexer.rb
+++ b/app/indexers/rights_metadata_indexer.rb
@@ -15,7 +15,7 @@ class RightsMetadataIndexer
       'copyright_ssim' => cocina.access.copyright,
       'use_statement_ssim' => cocina.access.useAndReproductionStatement,
       'use_license_machine_ssi' => license,
-      'rights_descriptions_ssim' => RightsDescriptionBuilder.build(cocina)
+      'rights_descriptions_ssim' => cocina.dro? ? RightsDescriptionBuilder.build(cocina) : CollectionRightsDescriptionBuilder.build(cocina)
     }.compact
   end
 

--- a/app/services/collection_rights_description_builder.rb
+++ b/app/services/collection_rights_description_builder.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Rights description builder for collections
+class CollectionRightsDescriptionBuilder
+  def self.build(cocina)
+    new(cocina).build
+  end
+
+  def initialize(cocina)
+    @cocina = cocina
+  end
+
+  def build
+    case cocina.access.access
+    when 'world'
+      'world'
+    else
+      'dark'
+    end
+  end
+
+  private
+
+  attr_reader :cocina
+end

--- a/app/services/rights_description_builder.rb
+++ b/app/services/rights_description_builder.rb
@@ -7,18 +7,19 @@ class RightsDescriptionBuilder
 
   def initialize(cocina)
     @cocina = cocina
+    @root_access_node = cocina.admin_policy? ? cocina.administrative.defaultAccess : cocina.access
   end
 
   def build
-    cocina.dro? ? rights_descriptions_for_item : rights_descriptions_for_collection
+    cocina.collection? ? rights_descriptions_for_collection : rights_descriptions_for_item_and_apo
   end
 
   private
 
-  attr_reader :cocina
+  attr_reader :cocina, :root_access_node
 
   def rights_descriptions_for_collection
-    case cocina.access.access
+    case @root_access_node.access
     when 'world'
       'world'
     else
@@ -26,17 +27,19 @@ class RightsDescriptionBuilder
     end
   end
 
-  def rights_descriptions_for_item
-    return 'controlled digital lending' if cocina.access.controlledDigitalLending
+  def rights_descriptions_for_item_and_apo
+    return 'controlled digital lending' if @root_access_node.controlledDigitalLending
 
-    return ['dark'] if cocina.access.access == 'dark'
+    return ['dark'] if @root_access_node.access == 'dark'
 
-    object_level_access + access_level_from_files.uniq.map { |str| "#{str} (file)" }
+    rights = object_level_access
+    rights += access_level_from_files.uniq.map { |str| "#{str} (file)" } if @cocina.dro?
+    rights
   end
 
   def access_level_from_files
     # dark access doesn't permit any file access
-    return [] if cocina.access.access == 'dark'
+    return [] if @root_access_node.access == 'dark'
 
     file_access_nodes.reject { |fa| same_as_object_access?(fa) }.flat_map do |fa|
       file_access_from_file(fa)
@@ -67,8 +70,8 @@ class RightsDescriptionBuilder
   end
 
   def same_as_object_access?(file_access)
-    (file_access[:access] == cocina.access.access && file_access[:download] == cocina.access.download) ||
-      (cocina.access.access == 'citation-only' && file_access[:access] == 'dark')
+    (file_access[:access] == @root_access_node.access && file_access[:download] == @root_access_node.download) ||
+      (@root_access_node.access == 'citation-only' && file_access[:access] == 'dark')
   end
 
   def file_access_nodes
@@ -79,17 +82,17 @@ class RightsDescriptionBuilder
   end
 
   def object_level_access
-    case cocina.access.access
+    case @root_access_node.access
     when 'citation-only'
       ['citation']
     when 'world'
       world_object_access
     when 'location-based'
-      case cocina.access.download
+      case @root_access_node.download
       when 'none'
-        ["location: #{cocina.access.readLocation} (no-download)"]
+        ["location: #{@root_access_node.readLocation} (no-download)"]
       else
-        ["location: #{cocina.access.readLocation}"]
+        ["location: #{@root_access_node.readLocation}"]
       end
     when 'stanford'
       stanford_object_access
@@ -97,19 +100,19 @@ class RightsDescriptionBuilder
   end
 
   def stanford_object_access
-    case cocina.access.download
+    case @root_access_node.download
     when 'none'
       ['stanford (no-download)']
     when 'location-based'
       # this is an odd case we might want to move away from. See https://github.com/sul-dlss/cocina-models/issues/258
-      ['stanford (no-download)', "location: #{cocina.access.readLocation}"]
+      ['stanford (no-download)', "location: #{@root_access_node.readLocation}"]
     else
       ['stanford']
     end
   end
 
   def world_object_access
-    case cocina.access.download
+    case @root_access_node.download
     when 'stanford'
       ['stanford', 'world (no-download)']
     when 'none'
@@ -118,7 +121,7 @@ class RightsDescriptionBuilder
       ['world']
     when 'location-based'
       # this is an odd case we might want to move away from. See https://github.com/sul-dlss/cocina-models/issues/258
-      ['world (no-download)', "location: #{cocina.access.readLocation}"]
+      ['world (no-download)', "location: #{@root_access_node.readLocation}"]
     end
   end
 end

--- a/app/services/rights_description_builder.rb
+++ b/app/services/rights_description_builder.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Rights description builder for items and apos
 class RightsDescriptionBuilder
   def self.build(cocina)
     new(cocina).build
@@ -11,23 +12,6 @@ class RightsDescriptionBuilder
   end
 
   def build
-    cocina.collection? ? rights_descriptions_for_collection : rights_descriptions_for_item_and_apo
-  end
-
-  private
-
-  attr_reader :cocina, :root_access_node
-
-  def rights_descriptions_for_collection
-    case @root_access_node.access
-    when 'world'
-      'world'
-    else
-      'dark'
-    end
-  end
-
-  def rights_descriptions_for_item_and_apo
     return 'controlled digital lending' if @root_access_node.controlledDigitalLending
 
     return ['dark'] if @root_access_node.access == 'dark'
@@ -36,6 +20,10 @@ class RightsDescriptionBuilder
     rights += access_level_from_files.uniq.map { |str| "#{str} (file)" } if @cocina.dro?
     rights
   end
+
+  private
+
+  attr_reader :cocina, :root_access_node
 
   def access_level_from_files
     # dark access doesn't permit any file access

--- a/spec/indexers/default_object_rights_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_indexer_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe DefaultObjectRightsIndexer do
           hasAgreement: 'druid:bb033gt0615',
           defaultAccess: {
             useAndReproductionStatement: 'Rights are owned by Stanford University Libraries.',
-            copyright: 'Additional copyright info'
+            copyright: 'Additional copyright info',
+            access: 'location-based',
+            download: 'location-based',
+            readLocation: 'spec'
           }
         }
       }
@@ -34,6 +37,8 @@ RSpec.describe DefaultObjectRightsIndexer do
       expect(doc).to match a_hash_including('use_statement_ssim' =>
         'Rights are owned by Stanford University Libraries.')
       expect(doc).to match a_hash_including('copyright_ssim' => 'Additional copyright info')
+      expect(doc).to match a_hash_including('rights_descriptions_ssim' => 'Dark')
+      expect(doc).to match a_hash_including('default_rights_descriptions_ssim' => ['location: spec'])
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/argo/issues/3121

- Index "Dark" into the rights description field for all APOs to fix the display of object rights for APOs
- Derive the display of default object rights for display on APOs into a new solr field

Will require updating Argo to recognize this new field and use it to add back the display of default object rights on APOs that was removed in https://github.com/sul-dlss/argo/pull/3123 


## How was this change tested? 🤨

- Existing tests for items/collections (indexing should unchanged despite the refactor)
- Update tests for APO indexing which has new fields


