### PR TITLE
[refactor] Extract DroRighsDescripionBuilder from RightsDescriptionBuilder

### DIFF
--- a/app/indexers/rights_metadata_indexer.rb
+++ b/app/indexers/rights_metadata_indexer.rb
@@ -15,7 +15,7 @@ class RightsMetadataIndexer
       'copyright_ssim' => cocina.access.copyright,
       'use_statement_ssim' => cocina.access.useAndReproductionStatement,
       'use_license_machine_ssi' => license,
-      'rights_descriptions_ssim' => cocina.dro? ? RightsDescriptionBuilder.build(cocina) : CollectionRightsDescriptionBuilder.build(cocina)
+      'rights_descriptions_ssim' => rights_description
     }.compact
   end
 
@@ -41,6 +41,12 @@ class RightsMetadataIndexer
     'https://opendatacommons.org/licenses/by/1-0/' => 'ODC-By-1.0',
     'https://opendatacommons.org/licenses/odbl/1-0/' => 'ODbL-1.0'
   }.freeze
+
+  def rights_description
+    return CollectionRightsDescriptionBuilder.build(cocina) if cocina.collection?
+
+    DroRightsDescriptionBuilder.build(cocina)
+  end
 
   # @return [String] the code if we've defined one, or the URI if we haven't.
   def license

--- a/app/services/dro_rights_description_builder.rb
+++ b/app/services/dro_rights_description_builder.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Rights description builder for items and apos
+class DroRightsDescriptionBuilder < RightsDescriptionBuilder
+  # @param [Cocina::Models::DRO] cocina_item
+
+  # This overrides the superclass
+  # @return [Cocina::Models::DROAccess]
+  def object_access
+    @object_access ||= cocina.access
+  end
+
+  private
+
+  def object_level_access
+    super + access_level_from_files.uniq.map { |str| "#{str} (file)" }
+  end
+
+  def access_level_from_files
+    # dark access doesn't permit any file access
+    return [] if object_access.access == 'dark'
+
+    file_access_nodes.reject { |fa| same_as_object_access?(fa) }.flat_map do |fa|
+      file_access_from_file(fa)
+    end
+  end
+
+  def file_access_from_file(file_access)
+    basic_access = if file_access[:access] == 'location-based'
+                     "location: #{file_access[:readLocation]}"
+                   else
+                     file_access[:access]
+                   end
+
+    return [basic_access] if file_access[:access] == file_access[:download]
+
+    basic_access += ' (no-download)' if file_access[:access] != 'dark'
+
+    case file_access[:download]
+    when 'stanford'
+      # Here we're using readLocation to mean download location. https://github.com/sul-dlss/cocina-models/issues/258
+      [basic_access, 'stanford']
+    when 'location-based'
+      # Here we're using readLocation to mean download location. https://github.com/sul-dlss/cocina-models/issues/258
+      [basic_access, "location: #{file_access[:readLocation]}"]
+    else
+      [basic_access]
+    end
+  end
+
+  def same_as_object_access?(file_access)
+    (file_access[:access] == object_access.access && file_access[:download] == object_access.download) ||
+      (object_access.access == 'citation-only' && file_access[:access] == 'dark')
+  end
+
+  def file_access_nodes
+    Array(cocina.structural.contains)
+      .flat_map { |fs| Array(fs.structural.contains) }
+      .map { |file| file.access.to_h }
+      .uniq
+  end
+end


### PR DESCRIPTION
No features added.

## Why was this change made? 🤔
This makes it easier to understand how only the DRO objects have file rights.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



