### PR TITLE
to make rights case consistent with collections/items

### DIFF
--- a/app/indexers/default_object_rights_indexer.rb
+++ b/app/indexers/default_object_rights_indexer.rb
@@ -14,7 +14,7 @@ class DefaultObjectRightsIndexer
     {
       'use_statement_ssim' => use_statement,
       'copyright_ssim' => copyright,
-      'rights_descriptions_ssim' => 'Dark',
+      'rights_descriptions_ssim' => 'dark',
       'default_rights_descriptions_ssim' => RightsDescriptionBuilder.build(cocina)
     }
   end

--- a/spec/indexers/default_object_rights_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_indexer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DefaultObjectRightsIndexer do
       expect(doc).to match a_hash_including('use_statement_ssim' =>
         'Rights are owned by Stanford University Libraries.')
       expect(doc).to match a_hash_including('copyright_ssim' => 'Additional copyright info')
-      expect(doc).to match a_hash_including('rights_descriptions_ssim' => 'Dark')
+      expect(doc).to match a_hash_including('rights_descriptions_ssim' => 'dark')
       expect(doc).to match a_hash_including('default_rights_descriptions_ssim' => ['location: spec'])
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Small change after #754 - just noticed that the case of rights shown to the user is all lower for items/collections ... make the APO rights consistent with this.

## How was this change tested? 🤨

Updated test



