### PR TITLE
Remove capistrano-rails and move common config to common config

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -16,21 +16,13 @@ install_plugin Capistrano::SCM::Git
 #   https://github.com/capistrano/rbenv
 #   https://github.com/capistrano/chruby
 #   https://github.com/capistrano/bundler
-#   https://github.com/capistrano/rails
 #
 # require 'capistrano/rvm'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
-# require 'capistrano/rails/assets'
-# require 'capistrano/rails/migrations'
 
 require 'capistrano/bundler'
 require 'capistrano/honeybadger'
-# most rails apps need this, but this one doesn't because there's no db to
-# migrate, and there are no assets to precompile
-# (https://github.com/capistrano/rails#usage)
-#
-# require 'capistrano/rails'
 require 'capistrano/passenger'
 require 'capistrano/shared_configs'
 require 'dlss/capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ group :deployment do
   gem 'capistrano', '~> 3.0'
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
-  gem 'capistrano-rails'
   gem 'capistrano-shared_configs'
   gem 'dlss-capistrano', '~> 3.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,9 +97,6 @@ GEM
       capistrano (~> 3.0)
     capistrano-passenger (0.2.1)
       capistrano (~> 3.0)
-    capistrano-rails (1.6.1)
-      capistrano (~> 3.1)
-      capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     cocina-models (0.65.1)
       activesupport
@@ -447,7 +444,6 @@ DEPENDENCIES
   capistrano (~> 3.0)
   capistrano-bundler
   capistrano-passenger
-  capistrano-rails
   capistrano-shared_configs
   committee
   config
@@ -483,4 +479,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.4
+   2.3.7

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,6 +12,9 @@ set :deploy_to, '/opt/app/dor_indexer/dor_indexing_app'
 set :linked_dirs, %w[log config/settings tmp/pids tmp/cache tmp/sockets vendor/bundle]
 set :linked_files, %w[config/secrets.yml config/honeybadger.yml config/newrelic.yml]
 
+set :rails_env, 'production'
+set :bundle_without, %w[test development deployment].join(' ')
+
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,7 +4,4 @@ server 'dor-indexing-app-prod-a.stanford.edu', user: 'dor_indexer', roles: %w[we
 server 'dor-indexing-app-prod-b.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 server 'dor-indexing-app-prod-c.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 
-set :rails_env, 'production'
-set :bundle_without, %w[test development deployment].join(' ')
-
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -3,7 +3,4 @@
 server 'dor-indexing-app-qa-a.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 server 'dor-indexing-app-qa-b.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 
-set :rails_env, 'production'
-set :bundle_without, %w[test development deployment].join(' ')
-
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,7 +3,4 @@
 server 'dor-indexing-app-stage-a.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 server 'dor-indexing-app-stage-b.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 
-set :rails_env, 'production'
-set :bundle_without, %w[test development deployment].join(' ')
-
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made? 🤔

This app does not use capistrano-rails so I'm not convinced we need all this cruft hanging around. If we ever add DB migrations or assets to DIA, we can always add this back. In the meantime, let it go.

Also, move common Capistrano config to... common Capistrano config. Having the Rails env and bundler without args in specific env configs is a relic of past practice where we had custom Rails envs.

## How was this change tested? 🤨

CI
