### PR TITLE
Define capistrano tasks for managing the rolling indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,26 @@ For more information about the fields and their purpose see: https://docs.google
 * There is a Camel route that sends messages from the fedora update topic https://github.com/sul-dlss/dor-camel-routes/blob/master/deploy/edu_stanford_dor-indexing-app-prod.indexing.xml#L116-L137
 
 ## Rolling indexer
-This helps keep the index fresh by reindexing the oldest data.
 
-```
-RAILS_ENV=production bin/rolling_index start
-RAILS_ENV=production bin/rolling_index stop
+This helps keep the index fresh by reindexing the oldest data. It is managed as a systemd service. To interact with it from your machine, you can use Capistrano:
 
+```shell
+$ cap ENV rolling_indexer:status
+$ cap ENV rolling_indexer:start
+$ cap ENV rolling_indexer:stop
+$ cap ENV rolling_indexer:restart
 ```
+
+Or if you're on a server that has the `rolling_indexer` capistrano role, use systemd commands:
+
+```shell
+$ sudo systemctl status rolling_index
+$ sudo systemctl start rolling_index
+$ sudo systemctl stop rolling_index
+$ sudo systemctl restart rolling_index
+```
+
+**NOTE**: The rolling indexer is automatically restarted during deployments.
 
 ## API
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,3 +23,38 @@ set :sneakers_systemd_use_hooks, true
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
+
+# Tasks for managing the rolling indexer
+namespace :rolling_indexer do
+  desc 'Stop rolling indexer'
+  task :stop do
+    on roles(:rolling_indexer) do
+      sudo :systemctl, 'stop', 'rolling-index'
+    end
+  end
+
+  desc 'Start rolling indexer'
+  task :start do
+    on roles(:rolling_indexer) do
+      sudo :systemctl, 'start', 'rolling-index'
+    end
+  end
+
+  desc 'Restart rolling indexer'
+  task :restart do
+    on roles(:rolling_indexer) do
+      sudo :systemctl, 'restart', 'rolling-index', raise_on_non_zero_exit: false
+    end
+  end
+
+  desc 'Print status of rolling indexer'
+  task :status do
+    on roles(:rolling_indexer) do
+      sudo :systemctl, 'status', 'rolling-index'
+    end
+  end
+end
+
+after 'deploy:failed', 'rolling_indexer:restart'
+after 'deploy:published', 'rolling_indexer:start'
+after 'deploy:starting', 'rolling_indexer:stop'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-indexing-app-prod-a.stanford.edu', user: 'dor_indexer', roles: %w[web app]
+server 'dor-indexing-app-prod-a.stanford.edu', user: 'dor_indexer', roles: %w[web app rolling_indexer]
 server 'dor-indexing-app-prod-b.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 server 'dor-indexing-app-prod-c.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-indexing-app-qa-a.stanford.edu', user: 'dor_indexer', roles: %w[web app]
+server 'dor-indexing-app-qa-a.stanford.edu', user: 'dor_indexer', roles: %w[web app rolling_indexer]
 server 'dor-indexing-app-qa-b.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-indexing-app-stage-a.stanford.edu', user: 'dor_indexer', roles: %w[web app]
+server 'dor-indexing-app-stage-a.stanford.edu', user: 'dor_indexer', roles: %w[web app rolling_indexer]
 server 'dor-indexing-app-stage-b.stanford.edu', user: 'dor_indexer', roles: %w[web app]
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
Fixes #732

## Why was this change made? 🤔

So we don't have to do this manually.

And run these tasks automatically, at appropriate points in the capistrano task flow, as part of regular deployment.

## How was this change tested? 🤨

Ran the tasks in QA.
