### PR TITLE
OpenAPI schema: add new cocina model related params for /dor/reindex

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -33,8 +33,8 @@ class DorController < ApplicationController
     RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
   end
 
-  def build_model_and_metadata(cocina_model_json:, created_at:, updated_at:)
-    model = Cocina::Models.build(JSON.parse(cocina_model_json))
+  def build_model_and_metadata(cocina_json:, created_at:, updated_at:)
+    model = Cocina::Models.build(JSON.parse(cocina_json))
     metadata = Dor::Services::Client::ObjectMetadata.new(created_at: created_at, updated_at: updated_at)
     Success([model, metadata])
   rescue StandardError
@@ -43,12 +43,12 @@ class DorController < ApplicationController
 
   # @returns [Success,Failure] the result of finding/parsing the model with metadata
   def cocina_with_metadata
-    cocina_model_json = params[:cocina_model_json].presence
+    cocina_json = params[:cocina_object].presence
     created_at = params[:created_at].presence
     updated_at = params[:updated_at].presence
-    return indexer.fetch_model_with_metadata unless cocina_model_json && created_at && updated_at
+    return indexer.fetch_model_with_metadata unless cocina_json && created_at && updated_at
 
-    build_model_and_metadata(cocina_model_json: cocina_model_json, created_at: created_at, updated_at: updated_at)
+    build_model_and_metadata(cocina_json: cocina_json, created_at: created_at, updated_at: updated_at)
   end
 
   def reindex_pid

--- a/openapi.yml
+++ b/openapi.yml
@@ -57,28 +57,31 @@ paths:
           required: false
           schema:
             type: integer
-        - name: cocina_object
-          in: query
-          description: the JSON serialization of the Cocina object
-          required: false
-          content:
-            application/json:
-              schema:
-                type: object
-        - name: created_at
-          in: query
-          description: the creation date of the Cocina object
-          required: false
-          schema:
-            type: string
-            format: date-time
-        - name: updated_at
-          in: query
-          description: the most recent modification date of the Cocina object
-          required: false
-          schema:
-            type: string
-            format: date-time
+      requestBody:
+        required: false
+        content:
+          '*/*':
+            schema:
+              type: object
+          application/json:
+            schema:
+              type: object
+              required:
+                - cocina_object
+                - created_at
+                - updated_at
+              properties:
+                cocina_object:
+                  description: JSON serialization of the Cocina object.  to be used, created_at and updated_at must also be provided.
+                  type: string
+                created_at:
+                  description: the creation date of the Cocina object
+                  type: string
+                  format: date-time
+                updated_at:
+                  description: the most recent modification date of the Cocina object
+                  type: string
+                  format: date-time
       responses:
         '200':
           description: Object successfully reindexed

--- a/openapi.yml
+++ b/openapi.yml
@@ -57,6 +57,28 @@ paths:
           required: false
           schema:
             type: integer
+        - name: cocina_model_json
+          in: query
+          description: the JSON serialization of the Cocina object
+          required: false
+          content:
+            application/json:
+              schema:
+                type: object
+        - name: created_at
+          in: query
+          description: the creation date of the Cocina object
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: updated_at
+          in: query
+          description: the most recent modification date of the Cocina object
+          required: false
+          schema:
+            type: string
+            format: date-time
       responses:
         '200':
           description: Object successfully reindexed

--- a/openapi.yml
+++ b/openapi.yml
@@ -57,7 +57,7 @@ paths:
           required: false
           schema:
             type: integer
-        - name: cocina_model_json
+        - name: cocina_object
           in: query
           description: the JSON serialization of the Cocina object
           required: false

--- a/spec/requests/dor_requests_spec.rb
+++ b/spec/requests/dor_requests_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'DOR', type: :request do
     end
 
     context 'when cocina is provided by caller' do
-      let(:cocina_model_json) { '{ "some": "json" }' }
+      let(:cocina_json) { '{ "some": "json" }' }
       let(:cocina_model_metadata) { instance_double(Dor::Services::Client::ObjectMetadata) }
       let(:created_at) { '2022-02-27' }
       let(:updated_at) { '2022-02-28' }
@@ -66,8 +66,8 @@ RSpec.describe 'DOR', type: :request do
       end
 
       it 'uses the provided cocina without hitting dor-services-app' do
-        allow(Cocina::Models).to receive(:build).with(JSON.parse(cocina_model_json)).and_return(cocina) # pretend our bogus test JSON is valid
-        post "/dor/reindex/#{druid}", params: { cocina_model_json: cocina_model_json, created_at: created_at, updated_at: updated_at }
+        allow(Cocina::Models).to receive(:build).with(JSON.parse(cocina_json)).and_return(cocina) # pretend our bogus test JSON is valid
+        post "/dor/reindex/#{druid}", params: { cocina_object: cocina_json, created_at: created_at, updated_at: updated_at }
         expect(response.body).to eq "Successfully updated index for #{druid}"
         expect(response.code).to eq '200'
         expect(mock_solr_conn).to have_received(:add).with(mock_solr_doc, add_attributes: { commitWithin: 1000 })
@@ -75,7 +75,7 @@ RSpec.describe 'DOR', type: :request do
       end
 
       it 'requires both the cocina json and the created_at/updated_at metadata' do
-        post "/dor/reindex/#{druid}", params: { cocina_model_json: cocina_model_json, updated_at: updated_at }
+        post "/dor/reindex/#{druid}", params: { cocina_object: cocina_json, updated_at: updated_at }
         expect(response.code).to eq '200'
         expect(mock_solr_conn).to have_received(:add).with(mock_solr_doc, add_attributes: { commitWithin: 1000 })
         expect(object_service).to have_received(:find_with_metadata)
@@ -84,7 +84,7 @@ RSpec.describe 'DOR', type: :request do
       it 'provides the caller with a useful error if invalid cocina is provided' do
         # Cocina::Models.build will be called with our bogus JSON, which will throw an error
         allow(Honeybadger).to receive(:notify).and_call_original
-        post "/dor/reindex/#{druid}", params: { cocina_model_json: cocina_model_json, created_at: created_at, updated_at: updated_at }
+        post "/dor/reindex/#{druid}", params: { cocina_object: cocina_json, created_at: created_at, updated_at: updated_at }
         expect(response.code).to eq '422' # the caller should've provided valid Cocina JSON
         expect(response.body).to eq "Error building Cocina model for #{druid}"
         expect(Honeybadger).to have_received(:notify) do |msg, context:, backtrace:|


### PR DESCRIPTION
## Why was this change made? 🤔

as @mjgiarlo pointed out, updates to the openapi.yml got missed in #769.

this seemed like the bare minimum, in that it adds the new optional params.

things that might be nice improvements, but that i wasn't sure how to implement (happy to read some docs and/or pair):
* schema for each of the new parameters that better constrains what values can be given for them.  i was unsure whether that'd require copypasta from another project's openapi.yml, or if there was something shared/centralized i could reference?
* ~~requirement for either all three new params or none of them.  i feel like i've seen a PR against one of our repos that enforced something like this via openapi.yml?~~ ended up taking care of this in the course of moving the new params to the request body.

also mjgiarlo and i were both slightly surprised that the new tests on #769 passed without an openapi.yml change 🤷 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

unit tests