### PR TITLE
Stop using partOfProject from the model

### DIFF
--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -9,8 +9,9 @@ class AdministrativeTagIndexer
 
   attr_reader :id
 
-  def initialize(id:, **)
+  def initialize(id:, administrative_tags:, **)
     @id = id
+    @administrative_tags = administrative_tags
   end
 
   # @return [Hash] the partial solr document for administrative tags
@@ -33,6 +34,8 @@ class AdministrativeTagIndexer
 
   private
 
+  attr_reader :administrative_tags
+
   # solrize each possible prefix for the tag, inclusive of the full tag.
   # e.g., for a tag such as "A : B : C", this will solrize to an _ssim field
   # that contains ["A",  "A : B",  "A : B : C"].
@@ -42,11 +45,5 @@ class AdministrativeTagIndexer
     1.upto(tag_parts.count).map do |i|
       tag_parts.take(i).join(TAG_PART_DELIMITER)
     end
-  end
-
-  def administrative_tags
-    Dor::Services::Client.object(id).administrative_tags.list
-  rescue Dor::Services::Client::NotFoundResponse
-    []
   end
 end

--- a/app/indexers/collection_title_indexer.rb
+++ b/app/indexers/collection_title_indexer.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class CollectionTitleIndexer
-  attr_reader :cocina, :parent_collections
+  attr_reader :cocina, :parent_collections, :administrative_tags
 
-  def initialize(cocina:, parent_collections:, **)
+  def initialize(cocina:, parent_collections:, administrative_tags:, **)
     @cocina = cocina
     @parent_collections = parent_collections
+    @administrative_tags = administrative_tags
   end
 
   # @return [Hash] the partial solr document for identifiable concerns
@@ -16,7 +17,7 @@ class CollectionTitleIndexer
       parent_collections.each do |related_obj|
         title = TitleBuilder.build(related_obj.description.title)
 
-        if related_obj.administrative.partOfProject == 'Hydrus'
+        if part_of_project_hydrus?
           # create/append hydrus_collection_title_ssim
           ::Solrizer.insert_field(solr_doc, 'hydrus_collection_title', title, :symbol)
         else
@@ -27,5 +28,9 @@ class CollectionTitleIndexer
         ::Solrizer.insert_field(solr_doc, 'collection_title', title, :stored_searchable, :symbol)
       end
     end
+  end
+
+  def part_of_project_hydrus?
+    administrative_tags.include?('Project : Hydrus')
   end
 end

--- a/app/indexers/fallback_indexer.rb
+++ b/app/indexers/fallback_indexer.rb
@@ -17,7 +17,13 @@ class FallbackIndexer
   attr_reader :id
 
   def to_solr
-    FALLBACK_INDEXER.new(id: id, resource: fetch_object).to_solr
+    FALLBACK_INDEXER.new(id: id, resource: fetch_object, administrative_tags: administrative_tags).to_solr
+  end
+
+  def administrative_tags
+    Dor::Services::Client.object(id).administrative_tags.list
+  rescue Dor::Services::Client::NotFoundResponse
+    []
   end
 
   def fetch_object

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AdministrativeTagIndexer do
   describe '#to_solr' do
     subject(:document) { indexer.to_solr }
 
-    let(:indexer) { described_class.new(id: 'druid:rt923jk234') }
+    let(:indexer) { described_class.new(id: 'druid:rt923jk234', administrative_tags: tags) }
 
     let(:tags) do
       [
@@ -17,11 +17,6 @@ RSpec.describe AdministrativeTagIndexer do
         'DPG : Beautiful Books : Octavo : newpri',
         'Remediated By : 4.15.4'
       ]
-    end
-
-    before do
-      # Don't actually hit the dor-services-app API endpoint
-      allow(indexer).to receive(:administrative_tags).and_return(tags)
     end
 
     it 'indexes all administrative tags' do

--- a/spec/indexers/collection_title_indexer_spec.rb
+++ b/spec/indexers/collection_title_indexer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CollectionTitleIndexer do
   end
 
   let(:indexer) do
-    described_class.new(cocina: cocina, parent_collections: collections)
+    described_class.new(cocina: cocina, parent_collections: collections, administrative_tags: [])
   end
 
   describe '#to_solr' do
@@ -47,7 +47,6 @@ RSpec.describe CollectionTitleIndexer do
     end
 
     context 'when related collections are provided' do
-      let(:project) { 'Google Books' }
       let(:collections) { [collection] }
 
       let(:collection) do
@@ -58,7 +57,6 @@ RSpec.describe CollectionTitleIndexer do
             'version' => 1,
             'label' => 'testing',
             'administrative' => {
-              'partOfProject' => project,
               'hasAdminPolicy' => apo_id
             },
             'access' => {},

--- a/spec/indexers/descriptive_metadata/contributor_spec.rb
+++ b/spec/indexers/descriptive_metadata/contributor_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/event_contributor_publisher_spec.rb
+++ b/spec/indexers/descriptive_metadata/event_contributor_publisher_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/event_date_creation_spec.rb
+++ b/spec/indexers/descriptive_metadata/event_date_creation_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/event_place_spec.rb
+++ b/spec/indexers/descriptive_metadata/event_place_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/format_spec.rb
+++ b/spec/indexers/descriptive_metadata/format_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/genre_spec.rb
+++ b/spec/indexers/descriptive_metadata/genre_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/language_spec.rb
+++ b/spec/indexers/descriptive_metadata/language_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/pub_year_1e_spec.rb
+++ b/spec/indexers/descriptive_metadata/pub_year_1e_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       		"useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
       	},
       	"administrative": {
-      		"hasAdminPolicy": "druid:zx485kb6348",
-      		"partOfProject": "H2"
+      		"hasAdminPolicy": "druid:zx485kb6348"
       	},
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
       	"identification": {

--- a/spec/indexers/descriptive_metadata/pub_year_spec.rb
+++ b/spec/indexers/descriptive_metadata/pub_year_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       		"useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
       	},
       	"administrative": {
-      		"hasAdminPolicy": "druid:zx485kb6348",
-      		"partOfProject": "H2"
+      		"hasAdminPolicy": "druid:zx485kb6348"
       	},
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
       	"identification": {

--- a/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/subject_temporal_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_temporal_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/subject_topic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_topic_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/title_spec.rb
+++ b/spec/indexers/descriptive_metadata/title_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata/type_of_resource_spec.rb
+++ b/spec/indexers/descriptive_metadata/type_of_resource_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
         },
         "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348",
-          "partOfProject": "H2"
+          "hasAdminPolicy": "druid:zx485kb6348"
         },
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
         "identification": {

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       		"useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
       	},
       	"administrative": {
-      		"hasAdminPolicy": "druid:zx485kb6348",
-      		"partOfProject": "H2"
+      		"hasAdminPolicy": "druid:zx485kb6348"
       	},
         "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
       	"identification": {

--- a/spec/indexers/identifiable_indexer_spec.rb
+++ b/spec/indexers/identifiable_indexer_spec.rb
@@ -93,8 +93,6 @@ RSpec.describe IdentifiableIndexer do
     end
 
     context 'when APO is found' do
-      let(:project) { 'Google Books' }
-
       let(:related) do
         Cocina::Models.build(
           {
@@ -103,7 +101,6 @@ RSpec.describe IdentifiableIndexer do
             'version' => 1,
             'label' => 'testing',
             'administrative' => {
-              'partOfProject' => project,
               'hasAdminPolicy' => apo_id
             },
             'access' => {},

--- a/spec/services/document_builder_spec.rb
+++ b/spec/services/document_builder_spec.rb
@@ -20,8 +20,15 @@ RSpec.describe DocumentBuilder do
   let(:admin_tags) do
     instance_double(AdministrativeTagIndexer, to_solr: { 'tag_ssim' => ['Test : Tag'] })
   end
+  let(:admin_tags_client) do
+    instance_double(Dor::Services::Client::AdministrativeTags, list: [])
+  end
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object, administrative_tags: admin_tags_client)
+  end
 
   before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(WorkflowFields).to receive(:for).and_return({ 'milestones_ssim' => %w[foo bar] })
     allow(ReleasableIndexer).to receive(:new).and_return(releasable)
     allow(WorkflowsIndexer).to receive(:new).and_return(workflows)
@@ -55,7 +62,7 @@ RSpec.describe DocumentBuilder do
 
     context 'with collections' do
       let(:object_client) do
-        instance_double(Dor::Services::Client::Object, find: related)
+        instance_double(Dor::Services::Client::Object, find: related, administrative_tags: admin_tags_client)
       end
       let(:related) do
         Cocina::Models.build(
@@ -78,10 +85,6 @@ RSpec.describe DocumentBuilder do
 
       let(:collections) { ['druid:bc999df2323'] }
 
-      before do
-        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      end
-
       it { is_expected.to be_instance_of CompositeIndexer::Instance }
     end
 
@@ -101,6 +104,7 @@ RSpec.describe DocumentBuilder do
           .with(cocina: Cocina::Models::DRO,
                 id: String,
                 metadata: metadata,
+                administrative_tags: [],
                 parent_collections: [])
         expect(Honeybadger).to have_received(:notify).with('Bad association found on druid:xx999xx9999. druid:bc999df2323 could not be found')
       end


### PR DESCRIPTION

## Why was this change made? 🤔
This field is going away so that we can support multiple project tags.

This change involved moving the project tag load call to before the indexer so that we didn't have to repeat calls.

Ref https://github.com/sul-dlss/common-accessioning/issues/851



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



