### PR TITLE
DorController: split ability for caller to provide cocina out into new method

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :dor do
     # TODO: Deprecate GET when caml POST can be implemented
     match 'reindex/:pid', action: :reindex, via: %i[get post put]
+    put 'reindex_from_cocina/:pid', action: :reindex_from_cocina
     match 'delete_from_index/:pid', action: :delete_from_index, via: %i[get post]
     get 'queue_size'
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -41,7 +41,7 @@ paths:
     post:
       tags:
         - indexing
-      summary: Reindex a repository object
+      summary: Reindex a repository object, using a network call to retrieve the Cocina model
       description: ''
       operationId: 'dor#reindex'
       parameters:
@@ -57,12 +57,42 @@ paths:
           required: false
           schema:
             type: integer
+      responses:
+        '200':
+          description: Object successfully reindexed
+          content:
+            text/plain: # This is why we can't enable Committee response validation. See TODO in config/application.rb
+              schema:
+                type: string
+        '404':
+          description: Object not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /dor/reindex_from_cocina/{pid}:
+    put:
+      tags:
+        - indexing
+      summary: Reindex a repository object using Cocina JSON provided by the caller
+      description: ''
+      operationId: 'dor#reindex_from_cocina'
+      parameters:
+        - name: pid
+          in: path
+          description: 'a digital repository identifier'
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
       requestBody:
         required: false
         content:
-          '*/*':
-            schema:
-              type: object
           application/json:
             schema:
               type: object
@@ -82,6 +112,9 @@ paths:
                   description: the most recent modification date of the Cocina object
                   type: string
                   format: date-time
+                commitWithin:
+                  description: 'time within which to trigger Solr commit'
+                  type: integer
       responses:
         '200':
           description: Object successfully reindexed
@@ -89,8 +122,8 @@ paths:
             text/plain: # This is why we can't enable Committee response validation. See TODO in config/application.rb
               schema:
                 type: string
-        '404':
-          description: Object not found
+        '422':
+          description: Unprocessable entity (the caller must provide valid Cocina)
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Why was this change made? 🤔

extract the ability for the caller to provide cocina from `#reindex` into `#reindex_from_cocina`, per discussion on slack about #770.

this lets us get rid of the weird specification of `*/*` as a possible content type for the request body in situations where no content type is specified because no request body is provided by the caller (@mjgiarlo suspects a bug in the committee gem, as that was needed for backward compatibility with the old `/dor/reindex` route's existing usage, otherwise committee would throw an error about the expectation that content type must be `application/json`).

see [here](https://github.com/sul-dlss/dor_indexing_app/pull/770#discussion_r819171190) and [here](https://stanfordlib.slack.com/archives/C09M7P91R/p1646353580348509?thread_ts=1646268578.925449&cid=C09M7P91R).


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

unit tests