### PR TITLE
Limit the errors that trigger failover indexer.

### DIFF
--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -42,7 +42,7 @@ class Indexer
     load_stats = Benchmark.measure('load_instance') do
       cocina_with_metadata = begin
         Success(Dor::Services::Client.object(pid).find_with_metadata)
-      rescue StandardError
+      rescue Dor::Services::Client::UnexpectedResponse
         Failure(:conversion_error)
       end
     end.format('%n realtime %rs total CPU %ts').gsub(/[()]/, '')


### PR DESCRIPTION
closes #781

## Why was this change made? 🤔
Correctly handle network issues.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit
