### PR TITLE
Handle not found in reindex by druid job.

### DIFF
--- a/app/jobs/reindex_by_druid_job.rb
+++ b/app/jobs/reindex_by_druid_job.rb
@@ -19,6 +19,11 @@ class ReindexByDruidJob
       cocina_with_metadata: cocina_with_metadata
     )
     ack!
+  rescue Dor::Services::Client::NotFoundResponse, Rubydora::RecordNotFound
+    Honeybadger.notify('Cannot reindex since not found. This may be because applications (e.g., PresCat) are creating workflow steps for deleted objects.',
+                       { druid: druid_from_message(msg) })
+    Rails.logger.info("Cannot reindex #{druid_from_message(msg)} by druid since it is not found.")
+    ack!
   end
 
   def solr

--- a/spec/jobs/reindex_by_druid_job_spec.rb
+++ b/spec/jobs/reindex_by_druid_job_spec.rb
@@ -5,16 +5,37 @@ require 'rails_helper'
 RSpec.describe ReindexByDruidJob do
   let(:message) { { druid: druid }.to_json }
   let(:druid) { 'druid:bc123df4567' }
-  let(:result) { Success(double) }
-  let(:indexer) { instance_double(Indexer, reindex_pid: true, fetch_model_with_metadata: result) }
+
+  let(:indexer) { instance_double(Indexer, reindex_pid: true) }
 
   before do
     allow(Indexer).to receive(:new).and_return(indexer)
   end
 
-  it 'updates the druid' do
-    described_class.new.work(message)
-    expect(indexer).to have_received(:reindex_pid)
-      .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: result)
+  context 'when object is found' do
+    let(:result) { Success(double) }
+
+    before do
+      allow(indexer).to receive(:fetch_model_with_metadata).and_return(result)
+    end
+
+    it 'updates the druid' do
+      described_class.new.work(message)
+      expect(indexer).to have_received(:reindex_pid)
+        .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: result)
+    end
+  end
+
+  context 'when object is not found' do
+    before do
+      allow(indexer).to receive(:fetch_model_with_metadata).and_raise(Dor::Services::Client::NotFoundResponse)
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'does not update the druid' do
+      described_class.new.work(message)
+      expect(indexer).not_to have_received(:reindex_pid)
+      expect(Honeybadger).to have_received(:notify)
+    end
   end
 end


### PR DESCRIPTION
closes #784

## Why was this change made? 🤔
Helpful HB alerts.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

