### PR TITLE
Stop using pid

### DIFF
--- a/app/jobs/reindex_by_druid_job.rb
+++ b/app/jobs/reindex_by_druid_job.rb
@@ -12,9 +12,9 @@ class ReindexByDruidJob
     druid = druid_from_message(msg)
     # Since we don't have the metadata (namely created_at) in the message,
     # we need another API call. :(
-    indexer = Indexer.new(solr: solr, pid: druid)
+    indexer = Indexer.new(solr: solr, identifier: druid)
     cocina_with_metadata = indexer.fetch_model_with_metadata
-    indexer.reindex_pid(
+    indexer.reindex(
       add_attributes: { commitWithin: 1000 },
       cocina_with_metadata: cocina_with_metadata
     )

--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -13,8 +13,8 @@ class ReindexJob
   def work(msg)
     cocina_with_metadata = build_cocina_model_from_json_str(msg)
     pid = cocina_with_metadata.value!.first.externalIdentifier
-    indexer = Indexer.new(solr: solr, pid: pid)
-    indexer.reindex_pid(
+    indexer = Indexer.new(solr: solr, identifier: pid)
+    indexer.reindex(
       add_attributes: { commitWithin: 1000 },
       cocina_with_metadata: cocina_with_metadata
     )

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -11,9 +11,9 @@ Daemons.run_proc('rolling index') do
     response = solr_conn.get 'select', params: QUERY
     response['response']['docs'].each do |doc|
       puts "Doc #{doc}"
-      indexer = Indexer.new(solr: solr_conn, pid: doc['id'])
+      indexer = Indexer.new(solr: solr_conn, identifier: doc['id'])
       cocina_with_metadata = indexer.fetch_model_with_metadata
-      indexer.reindex_pid(
+      indexer.reindex(
         add_attributes: { commitWithin: 1000 },
         cocina_with_metadata: cocina_with_metadata
       )

--- a/spec/jobs/reindex_by_druid_job_spec.rb
+++ b/spec/jobs/reindex_by_druid_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ReindexByDruidJob do
   let(:message) { { druid: druid }.to_json }
   let(:druid) { 'druid:bc123df4567' }
 
-  let(:indexer) { instance_double(Indexer, reindex_pid: true) }
+  let(:indexer) { instance_double(Indexer, reindex: true) }
 
   before do
     allow(Indexer).to receive(:new).and_return(indexer)
@@ -21,7 +21,7 @@ RSpec.describe ReindexByDruidJob do
 
     it 'updates the druid' do
       described_class.new.work(message)
-      expect(indexer).to have_received(:reindex_pid)
+      expect(indexer).to have_received(:reindex)
         .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: result)
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe ReindexByDruidJob do
 
     it 'does not update the druid' do
       described_class.new.work(message)
-      expect(indexer).not_to have_received(:reindex_pid)
+      expect(indexer).not_to have_received(:reindex)
       expect(Honeybadger).to have_received(:notify)
     end
   end

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ReindexJob do
   end
 
   let(:result) { Success(double) }
-  let(:indexer) { instance_double(Indexer, reindex_pid: true) }
+  let(:indexer) { instance_double(Indexer, reindex: true) }
 
   before do
     allow(Indexer).to receive(:new).and_return(indexer)
@@ -28,7 +28,7 @@ RSpec.describe ReindexJob do
 
   it 'updates the druid' do
     described_class.new.work(message)
-    expect(indexer).to have_received(:reindex_pid)
+    expect(indexer).to have_received(:reindex)
       .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: Success(Array))
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔

pid is a fedora specific term.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



