### PR TITLE
Rename the pid parameter in the routes to id

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -9,7 +9,7 @@ class DorController < ApplicationController
   def reindex
     cocina_with_metadata = indexer.fetch_model_with_metadata
     reindex_object(cocina_with_metadata)
-    render status: :ok, plain: "Successfully updated index for #{params[:pid]}"
+    render status: :ok, plain: "Successfully updated index for #{params[:id]}"
   rescue Dor::Services::Client::NotFoundResponse, Rubydora::RecordNotFound
     render status: :not_found, plain: 'Object does not exist in the repository'
   end
@@ -19,17 +19,17 @@ class DorController < ApplicationController
                                                     created_at: params[:created_at].presence,
                                                     updated_at: params[:updated_at].presence)
     reindex_object(cocina_with_metadata)
-    render status: :ok, plain: "Successfully updated index for #{params[:pid]}"
+    render status: :ok, plain: "Successfully updated index for #{params[:id]}"
   rescue CocinaModelBuildError => e
     request.session # TODO: calling this as a hack to address bad Rails/HB interaction, remove when https://github.com/rails/rails/issues/43922 is fixed
-    Honeybadger.notify('Error building Cocina model', context: { druid: params[:pid], build_error: e.cause.message }, backtrace: e.cause.backtrace)
-    render status: :unprocessable_entity, plain: "Error building Cocina model for #{params[:pid]}"
+    Honeybadger.notify('Error building Cocina model', context: { druid: params[:id], build_error: e.cause.message }, backtrace: e.cause.backtrace)
+    render status: :unprocessable_entity, plain: "Error building Cocina model for #{params[:id]}"
   end
 
   def delete_from_index
-    solr.delete_by_id(params[:pid], commitWithin: params.fetch(:commitWithin, 1000).to_i)
+    solr.delete_by_id(params[:id], commitWithin: params.fetch(:commitWithin, 1000).to_i)
     solr.commit unless params[:commitWithin]
-    render plain: params[:pid]
+    render plain: params[:id]
   end
 
   private
@@ -47,7 +47,7 @@ class DorController < ApplicationController
   end
 
   def indexer
-    @indexer ||= Indexer.new(solr: solr, identifier: params[:pid])
+    @indexer ||= Indexer.new(solr: solr, identifier: params[:id])
   end
 
   def reindex_object(cocina_with_metadata)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ Rails.application.routes.draw do
 
   namespace :dor do
     # TODO: Deprecate GET when caml POST can be implemented
-    match 'reindex/:pid', action: :reindex, via: %i[get post put]
-    put 'reindex_from_cocina/:pid', action: :reindex_from_cocina
-    match 'delete_from_index/:pid', action: :delete_from_index, via: %i[get post]
+    match 'reindex/:id', action: :reindex, via: %i[get post put]
+    put 'reindex_from_cocina/:id', action: :reindex_from_cocina
+    match 'delete_from_index/:id', action: :delete_from_index, via: %i[get post]
     get 'queue_size'
   end
 end

--- a/spec/routing/dor_spec.rb
+++ b/spec/routing/dor_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe 'Dor routing', type: :routing do
       expect(get: '/dor/reindex/druid:abc123').to route_to(
         controller: 'dor',
         action: 'reindex',
-        pid: 'druid:abc123'
+        id: 'druid:abc123'
       )
       expect(post: '/dor/reindex/druid:abc123').to route_to(
         controller: 'dor',
         action: 'reindex',
-        pid: 'druid:abc123'
+        id: 'druid:abc123'
       )
       expect(put: '/dor/reindex/druid:abc123').to route_to(
         controller: 'dor',
         action: 'reindex',
-        pid: 'druid:abc123'
+        id: 'druid:abc123'
       )
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
pid is from Fedora, but we aren't dealing with Fedora anymore.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



