### PR TITLE
/dor/reindex_from_cocina can parse druid from json, remove redundant druid from URL path

### DIFF
--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -18,12 +18,13 @@ class DorController < ApplicationController
     cocina_with_metadata = build_model_and_metadata(cocina_json: params[:cocina_object].presence,
                                                     created_at: params[:created_at].presence,
                                                     updated_at: params[:updated_at].presence)
-    reindex_object(cocina_with_metadata)
-    render status: :ok, plain: "Successfully updated index for #{params[:id]}"
+    druid = cocina_with_metadata.first.externalIdentifier
+    reindex_object(Success(cocina_with_metadata))
+    render status: :ok, plain: "Successfully updated index for #{druid}"
   rescue CocinaModelBuildError => e
     request.session # TODO: calling this as a hack to address bad Rails/HB interaction, remove when https://github.com/rails/rails/issues/43922 is fixed
-    Honeybadger.notify('Error building Cocina model', context: { druid: params[:id], build_error: e.cause.message }, backtrace: e.cause.backtrace)
-    render status: :unprocessable_entity, plain: "Error building Cocina model for #{params[:id]}"
+    Honeybadger.notify('Error building Cocina model', context: { cocina: params[:cocina_object], build_error: e.cause.message }, backtrace: e.cause.backtrace)
+    render status: :unprocessable_entity, plain: "Error building Cocina model from json: #{params[:cocina_object]}"
   end
 
   def delete_from_index
@@ -41,7 +42,7 @@ class DorController < ApplicationController
   def build_model_and_metadata(cocina_json:, created_at:, updated_at:)
     model = Cocina::Models.build(JSON.parse(cocina_json))
     metadata = Dor::Services::Client::ObjectMetadata.new(created_at: created_at, updated_at: updated_at)
-    Success([model, metadata])
+    [model, metadata]
   rescue StandardError
     raise CocinaModelBuildError
   end

--- a/app/controllers/dor_controller.rb
+++ b/app/controllers/dor_controller.rb
@@ -15,7 +15,9 @@ class DorController < ApplicationController
   end
 
   def reindex_from_cocina
-    cocina_with_metadata = build_model_and_metadata(cocina_json: params[:cocina_object].presence,
+    # params[:cocina_object] is itself an ActionController::Parameters instance, hence the #require and #to_unsafe_h
+    cocina_hash = params.require(:cocina_object).to_unsafe_h
+    cocina_with_metadata = build_model_and_metadata(cocina_hash: cocina_hash,
                                                     created_at: params[:created_at].presence,
                                                     updated_at: params[:updated_at].presence)
     druid = cocina_with_metadata.first.externalIdentifier
@@ -23,8 +25,9 @@ class DorController < ApplicationController
     render status: :ok, plain: "Successfully updated index for #{druid}"
   rescue CocinaModelBuildError => e
     request.session # TODO: calling this as a hack to address bad Rails/HB interaction, remove when https://github.com/rails/rails/issues/43922 is fixed
-    Honeybadger.notify('Error building Cocina model', context: { cocina: params[:cocina_object], build_error: e.cause.message }, backtrace: e.cause.backtrace)
-    render status: :unprocessable_entity, plain: "Error building Cocina model from json: #{params[:cocina_object]}"
+    hb_context = { cocina: cocina_hash.deep_symbolize_keys, build_error: e.cause.message } # calling #deep_symbolize_keys makes for a more readable hash
+    Honeybadger.notify('Error building Cocina model', context: hb_context, backtrace: e.cause.backtrace)
+    render status: :unprocessable_entity, plain: "Error building Cocina model from json: '#{e.cause.message}'; cocina=#{cocina_hash.to_json}"
   end
 
   def delete_from_index
@@ -39,8 +42,8 @@ class DorController < ApplicationController
     RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
   end
 
-  def build_model_and_metadata(cocina_json:, created_at:, updated_at:)
-    model = Cocina::Models.build(JSON.parse(cocina_json))
+  def build_model_and_metadata(cocina_hash:, created_at:, updated_at:)
+    model = Cocina::Models.build(cocina_hash)
     metadata = Dor::Services::Client::ObjectMetadata.new(created_at: created_at, updated_at: updated_at)
     [model, metadata]
   rescue StandardError

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   namespace :dor do
     # TODO: Deprecate GET when caml POST can be implemented
     match 'reindex/:id', action: :reindex, via: %i[get post put]
-    put 'reindex_from_cocina/:id', action: :reindex_from_cocina
+    put 'reindex_from_cocina', action: :reindex_from_cocina
     match 'delete_from_index/:id', action: :delete_from_index, via: %i[get post]
     get 'queue_size'
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -96,7 +96,7 @@ paths:
               properties:
                 cocina_object:
                   description: JSON serialization of the Cocina object.  to be used, created_at and updated_at must also be provided.
-                  type: string
+                  type: object
                 created_at:
                   description: the creation date of the Cocina object
                   type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -76,20 +76,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /dor/reindex_from_cocina/{pid}:
+  /dor/reindex_from_cocina:
     put:
       tags:
         - indexing
       summary: Reindex a repository object using Cocina JSON provided by the caller
       description: ''
       operationId: 'dor#reindex_from_cocina'
-      parameters:
-        - name: pid
-          in: path
-          description: 'a digital repository identifier'
-          required: true
-          schema:
-            $ref: '#/components/schemas/Druid'
       requestBody:
         required: false
         content:


### PR DESCRIPTION
## Why was this change made? 🤔

realized having the druid in the URL path was redundant and introduced opportunity for confusion if druid isn't parseable from cocina or if it differs.  see https://github.com/sul-dlss/dor-services-app/pull/3683#discussion_r822069566

connects with sul-dlss/dor-services-app#3651

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

- [x] unit test
- [x] integration tests

ran integration tests against QA with sul-dlss/dor-services-app#3683 and sul-dlss/dor_indexing_app#803 deployed, all passed.