### PR TITLE
Removes use of deprecated find_with_metadata.

### DIFF
--- a/app/indexers/data_indexer.rb
+++ b/app/indexers/data_indexer.rb
@@ -2,10 +2,9 @@
 
 # Indexing provided by ActiveFedora
 class DataIndexer
-  attr_reader :metadata, :cocina
+  attr_reader :cocina
 
-  def initialize(metadata:, cocina:, **)
-    @metadata = metadata
+  def initialize(cocina:, **)
     @cocina = cocina
   end
 
@@ -30,11 +29,11 @@ class DataIndexer
   end
 
   def modified_latest
-    metadata.updated_at.to_datetime.strftime('%FT%TZ')
+    cocina.modified.to_datetime.strftime('%FT%TZ')
   end
 
   def created_at
-    metadata.created_at.to_datetime.strftime('%FT%TZ')
+    cocina.created.to_datetime.strftime('%FT%TZ')
   end
 
   def legacy_collections

--- a/app/indexers/identifiable_indexer.rb
+++ b/app/indexers/identifiable_indexer.rb
@@ -18,7 +18,7 @@ class IdentifiableIndexer
     {}.tap do |solr_doc|
       add_apo_titles(solr_doc, cocina.administrative.hasAdminPolicy)
 
-      solr_doc['metadata_source_ssi'] = identity_metadata_source unless cocina.is_a? Cocina::Models::AdminPolicy
+      solr_doc['metadata_source_ssi'] = identity_metadata_source unless cocina.is_a? Cocina::Models::AdminPolicyWithMetadata
       # This used to be added to the index by https://github.com/sul-dlss/dor-services/commit/11b80d249d19326ef591411ffeb634900e75c2c3
       # and was called dc_identifier_druid_tesim
       # It is used to search based on druid.

--- a/app/indexers/identity_metadata_indexer.rb
+++ b/app/indexers/identity_metadata_indexer.rb
@@ -42,9 +42,9 @@ class IdentityMetadataIndexer
 
   def object_type
     case cocina_object
-    when Cocina::Models::AdminPolicy
+    when Cocina::Models::AdminPolicyWithMetadata
       'adminPolicy'
-    when Cocina::Models::Collection
+    when Cocina::Models::CollectionWithMetadata
       'collection'
     else
       cocina_object.type == Cocina::Models::ObjectType.agreement ? 'agreement' : 'item'

--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -12,7 +12,7 @@ class ReindexJob
 
   def work(msg)
     cocina_with_metadata = build_cocina_model_from_json_str(msg)
-    pid = cocina_with_metadata.value!.first.externalIdentifier
+    pid = cocina_with_metadata.value!.externalIdentifier
     indexer = Indexer.new(solr: solr, identifier: pid)
     indexer.reindex(
       add_attributes: { commitWithin: 1000 },
@@ -28,9 +28,8 @@ class ReindexJob
   def build_cocina_model_from_json_str(str)
     json = JSON.parse(str)
     model = Cocina::Models.build(json.fetch('model'))
-
-    metadata = Dor::Services::Client::ObjectMetadata.new(updated_at: json.fetch('modified_at'),
-                                                         created_at: json.fetch('created_at'))
-    Success([model, metadata])
+    # Lock is required, but we don't know what it is. Since not updating, that is OK.
+    model_with_metadata = Cocina::Models.with_metadata(model, 'unknown_lock', created: DateTime.parse(json.fetch('created_at')), modified: DateTime.parse(json.fetch('modified_at')))
+    Success(model_with_metadata)
   end
 end

--- a/app/services/document_builder.rb
+++ b/app/services/document_builder.rb
@@ -45,16 +45,14 @@ class DocumentBuilder
     Cocina::Models::ObjectType.collection => COLLECTION_INDEXER
   }.freeze
 
-  # @param [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Model::AdminPolicy] model
-  # @param [Hash<String,String>] metadata this contains the updated and created dates
-  def self.for(model:, metadata:)
+  # @param [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Model::AdminPolicyWithMetadata] model
+  def self.for(model:)
     id = model.externalIdentifier
     Rails.logger.debug { "Fetching indexer for #{model.type}" }
     indexer_for_type(model.type).new(id: id,
                                      cocina: model,
                                      parent_collections: load_parent_collections(model),
-                                     administrative_tags: administrative_tags(id),
-                                     metadata: metadata)
+                                     administrative_tags: administrative_tags(id))
   end
 
   def self.indexer_for_type(type)

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -33,8 +33,8 @@ class Indexer
     # benchmark how long it takes to convert the object to a Solr document
     to_solr_stats = Benchmark.measure('to_solr') do
       solr_doc = if cocina_with_metadata.success?
-                   model, metadata = cocina_with_metadata.value!
-                   DocumentBuilder.for(model: model, metadata: metadata).to_solr
+                   model = cocina_with_metadata.value!
+                   DocumentBuilder.for(model: model).to_solr
                  else
                    logger.debug("Fetching fallback indexer because cocina model couldn't be retrieved.")
                    FallbackIndexer.new(id: identifier).to_solr
@@ -55,7 +55,7 @@ class Indexer
     # benchmark how long it takes to load the object
     load_stats = Benchmark.measure('load_instance') do
       cocina_with_metadata = begin
-        Success(Dor::Services::Client.object(identifier).find_with_metadata)
+        Success(Dor::Services::Client.object(identifier).find)
       rescue Dor::Services::Client::UnexpectedResponse
         Failure(:conversion_error)
       end

--- a/spec/indexers/data_indexer_spec.rb
+++ b/spec/indexers/data_indexer_spec.rb
@@ -4,18 +4,20 @@ require 'rails_helper'
 
 RSpec.describe DataIndexer do
   let(:cocina) do
-    Cocina::Models::DRO.new(externalIdentifier: 'druid:xx999xx9999',
-                            type: Cocina::Models::ObjectType.map,
-                            label: 'test label',
-                            version: 4,
-                            description: {
-                              title: [{ value: 'test label' }],
-                              purl: 'https://purl.stanford.edu/xx999xx9999'
-                            },
-                            access: {},
-                            administrative: { hasAdminPolicy: 'druid:vv888vv8888' },
-                            structural: structural,
-                            identification: { sourceId: 'sul:1234' })
+    dro = Cocina::Models::DRO.new(externalIdentifier: 'druid:xx999xx9999',
+                                  type: Cocina::Models::ObjectType.map,
+                                  label: 'test label',
+                                  version: 4,
+                                  description: {
+                                    title: [{ value: 'test label' }],
+                                    purl: 'https://purl.stanford.edu/xx999xx9999'
+                                  },
+                                  access: {},
+                                  administrative: { hasAdminPolicy: 'druid:vv888vv8888' },
+                                  structural: structural,
+                                  identification: { sourceId: 'sul:1234' })
+    Cocina::Models.with_metadata(dro, 'abc123', created: DateTime.parse('Wed, 01 Jan 2020 12:00:01 GMT'),
+                                                modified: DateTime.parse('Thu, 04 Mar 2021 23:05:34 GMT'))
   end
 
   before do
@@ -23,15 +25,10 @@ RSpec.describe DataIndexer do
   end
 
   describe '#to_solr' do
-    let(:metadata) do
-      instance_double(Dor::Services::Client::ObjectMetadata,
-                      updated_at: 'Thu, 04 Mar 2021 23:05:34 GMT',
-                      created_at: 'Wed, 01 Jan 2020 12:00:01 GMT')
-    end
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(id: 'druid:ab123cd4567', cocina: cocina, metadata: metadata)
+      ).new(id: 'druid:ab123cd4567', cocina: cocina)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_indexer_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe IdentityMetadataIndexer do
     context 'with a collection' do
       # Collection objects have no structural attribute
       let(:cocina) do
-        Cocina::Models.build({
+        collection = Cocina::Models.build({
           externalIdentifier: 'druid:rt923jk3421',
           type: type,
           version: 1,
@@ -99,6 +99,7 @@ RSpec.describe IdentityMetadataIndexer do
           },
           identification: identification
         }.with_indifferent_access)
+        Cocina::Models.with_metadata(collection, 'abc123')
       end
       let(:type) { Cocina::Models::ObjectType.collection }
       let(:identification) do

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe ReindexJob do
   it 'updates the druid' do
     described_class.new.work(message)
     expect(indexer).to have_received(:reindex)
-      .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: Success(Array))
+      .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: Success(Cocina::Models::DROWithMetadata))
   end
 end

--- a/spec/services/document_builder_spec.rb
+++ b/spec/services/document_builder_spec.rb
@@ -3,13 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe DocumentBuilder do
-  subject(:indexer) { described_class.for(model: cocina, metadata: metadata) }
+  subject(:indexer) { described_class.for(model: cocina_with_metadata) }
 
-  let(:metadata) do
-    instance_double(Dor::Services::Client::ObjectMetadata,
-                    updated_at: 'Thu, 04 Mar 2021 23:05:34 GMT',
-                    created_at: 'Wed, 01 Jan 2020 12:00:01 GMT')
+  let(:cocina_with_metadata) do
+    Cocina::Models.with_metadata(cocina, 'unknown_lock', created: DateTime.parse('Wed, 01 Jan 2020 12:00:01 GMT'), modified: DateTime.parse('Thu, 04 Mar 2021 23:05:34 GMT'))
   end
+
   let(:druid) { 'druid:xx999xx9999' }
   # rubocop:disable Style/StringHashKeys
   let(:releasable) do
@@ -111,9 +110,8 @@ RSpec.describe DocumentBuilder do
 
         # Ensure that errors are stripped out of parent_collections
         expect(AdministrativeTagIndexer).to have_received(:new)
-          .with(cocina: Cocina::Models::DRO,
+          .with(cocina: Cocina::Models::DROWithMetadata,
                 id: String,
-                metadata: metadata,
                 administrative_tags: [],
                 parent_collections: [])
         expect(Honeybadger).to have_received(:notify).with('Bad association found on druid:xx999xx9999. druid:bc999df2323 could not be found')

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe Indexer do
       let(:doc_builder) { instance_double(CompositeIndexer::Instance, to_solr: doc) }
       let(:doc) { instance_double(Hash) }
       let(:model) { instance_double(Object) }
-      let(:metadata) { instance_double(Object) }
-      let(:object_client) { instance_double(Dor::Services::Client::Object, find_with_metadata: [model, metadata]) }
+      let(:object_client) { instance_double(Dor::Services::Client::Object, find: model) }
 
       before do
         allow(DocumentBuilder).to receive(:for).and_return(doc_builder)
@@ -28,7 +27,7 @@ RSpec.describe Indexer do
 
       it 'works' do
         load_and_index
-        expect(DocumentBuilder).to have_received(:for).with(model: model, metadata: metadata)
+        expect(DocumentBuilder).to have_received(:for).with(model: model)
         expect(doc_builder).to have_received(:to_solr)
         expect(solr).to have_received(:add).with(doc, { add_attributes: { commitWithin: 1000 } })
       end
@@ -38,7 +37,7 @@ RSpec.describe Indexer do
       let(:object_client) { instance_double(Dor::Services::Client::Object) }
 
       before do
-        allow(object_client).to receive(:find_with_metadata).and_raise(Dor::Services::Client::NotFoundResponse)
+        allow(object_client).to receive(:find).and_raise(Dor::Services::Client::NotFoundResponse)
       end
 
       it 'does not update the druid' do


### PR DESCRIPTION
closes #828

## Why was this change made? 🤔
Remove use of deprecated method.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, qa

