### PR TITLE
use cocina-models factory for test objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ end
 
 group :development, :test do
   gem 'byebug'
+  gem 'rspec', '~> 3.0' # need this to use cocina-models factories
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 5.0'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,10 @@ GEM
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -454,6 +458,7 @@ DEPENDENCIES
   rack-timeout (~> 0.5.1)
   rails (~> 7.0.0)
   rsolr (~> 2.0)
+  rspec (~> 3.0)
   rspec-rails (~> 5.0)
   rspec_junit_formatter
   rubocop (~> 1.0)

--- a/spec/indexers/collection_title_indexer_spec.rb
+++ b/spec/indexers/collection_title_indexer_spec.rb
@@ -5,38 +5,13 @@ require 'rails_helper'
 RSpec.describe CollectionTitleIndexer do
   let(:druid) { 'druid:rt923jk3422' }
   let(:apo_id) { 'druid:bd999bd9999' }
-  let(:cocina) do
-    Cocina::Models.build(
-      {
-        externalIdentifier: druid,
-        type: Cocina::Models::ObjectType.image,
-        version: 1,
-        label: 'testing',
-        access: {},
-        administrative: {
-          hasAdminPolicy: apo_id
-        },
-        description: {
-          title: [{ value: 'Test obj' }],
-          subject: [{ type: 'topic', value: 'word' }],
-          purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-        },
-        structural: {
-          contains: [],
-          isMemberOf: []
-        },
-        identification: { sourceId: 'sul:1234' }
-      }
-    )
-  end
-
-  let(:indexer) do
-    described_class.new(cocina: cocina, parent_collections: collections, administrative_tags: [])
-  end
+  let(:cocina_item) { build(:dro, id: druid) }
+  let(:indexer) { described_class.new(cocina: cocina_item, parent_collections: collections, administrative_tags: []) }
 
   describe '#to_solr' do
     let(:doc) { indexer.to_solr }
-    let(:mock_rel_druid) { 'druid:qf999gg9999' }
+    let(:bare_collection_druid) { 'qf999gg9999' }
+    let(:collection_druid) { "druid:#{bare_collection_druid}" }
 
     context 'when no collections are provided' do
       let(:collections) { [] }
@@ -49,30 +24,11 @@ RSpec.describe CollectionTitleIndexer do
 
     context 'when related collections are provided' do
       let(:collections) { [collection] }
+      let(:collection) { build(:collection, id: collection_druid, title: 'Collection test object') }
 
-      let(:collection) do
-        Cocina::Models.build(
-          {
-            externalIdentifier: mock_rel_druid,
-            type: Cocina::Models::ObjectType.collection,
-            version: 1,
-            label: 'testing',
-            administrative: {
-              hasAdminPolicy: apo_id
-            },
-            access: {},
-            description: {
-              title: [{ value: 'Test object' }],
-              purl: "https://purl.stanford.edu/#{mock_rel_druid.delete_prefix('druid:')}"
-            },
-            identification: { sourceId: 'sul:1234' }
-          }
-        )
-      end
-
-      it 'generate collection title fields' do
-        expect(doc[Solrizer.solr_name('collection_title', :symbol)].first).to eq 'Test object'
-        expect(doc[Solrizer.solr_name('collection_title', :stored_searchable)].first).to eq 'Test object'
+      it 'generates collection title fields' do
+        expect(doc[Solrizer.solr_name('collection_title', :symbol)].first).to eq 'Collection test object'
+        expect(doc[Solrizer.solr_name('collection_title', :stored_searchable)].first).to eq 'Collection test object'
       end
     end
   end

--- a/spec/indexers/content_metadata_indexer_spec.rb
+++ b/spec/indexers/content_metadata_indexer_spec.rb
@@ -3,185 +3,170 @@
 require 'rails_helper'
 
 RSpec.describe ContentMetadataIndexer do
-  let(:json) do
-    <<~JSON
+  let(:bare_druid) { 'cs178jh7817' }
+  let(:druid) { "druid:#{bare_druid}" }
+  let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid, type: Cocina::Models::ObjectType.map).new(
       {
-        "type": "#{Cocina::Models::ObjectType.map}",
-        "externalIdentifier": "druid:cs178jh7817",
-        "label": "Some more screenshots",
-        "version": 1,
-        "description": {
-          "title": [{ "value": "Some more screenshots" }],
-          "purl": "https://purl.stanford.edu/cs178jh7817"
-        },
-        "access": {
-          "view": "world",
-          "download": "world"
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "identification": {
-          "sourceId": "hydrus:72"
-        },
-        "structural": {#{structural}}
+        structural: structural,
+        access: {
+          view: 'world',
+          download: 'world'
+        }
       }
-    JSON
+    )
   end
-
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:indexer) do
-    described_class.new(id: 'druid:ab123cd4567', cocina: cocina)
-  end
+  let(:indexer) { described_class.new(cocina: cocina) }
 
   describe '#to_solr' do
     subject(:doc) { indexer.to_solr }
 
     context 'when the object contains file_sets' do
       let(:structural) do
-        <<~JSON
-          "contains": [
+        {
+          contains: [
             {
-              "type": "#{Cocina::Models::FileSetType.file}",
-              "externalIdentifier": "0001",
-              "label": "0001",
-              "version": 1,
-              "structural": {
-                "contains": [
+              type: Cocina::Models::FileSetType.file,
+              externalIdentifier: '0001',
+              label: '0001',
+              version: 1,
+              structural: {
+                contains: [
                   {
-                    "type": "#{Cocina::Models::ObjectType.file}",
-                    "externalIdentifier": "druid:cs178jh7817/gw177fc7976_05_0001.jp2",
-                    "label": "gw177fc7976_05_0001.jp2",
-                    "filename": "gw177fc7976_05_0001.jp2",
-                    "size": 5143883,
-                    "version": 1,
-                    "hasMimeType": "image/jp2",
-                    "hasMessageDigests": [
+                    type: Cocina::Models::ObjectType.file,
+                    externalIdentifier: 'druid:cs178jh7817/gw177fc7976_05_0001.jp2',
+                    label: 'gw177fc7976_05_0001.jp2',
+                    filename: 'gw177fc7976_05_0001.jp2',
+                    size: 5_143_883,
+                    version: 1,
+                    hasMimeType: 'image/jp2',
+                    hasMessageDigests: [
                       {
-                        "type": "sha1",
-                        "digest": "ca1eb0edd09a21f9dd9e3a89abc790daf4d04916"
+                        type: 'sha1',
+                        digest: 'ca1eb0edd09a21f9dd9e3a89abc790daf4d04916'
                       },
                       {
-                        "type": "md5",
-                        "digest": "3d3ff46d98f3d517d0bf086571e05c18"
+                        type: 'md5',
+                        digest: '3d3ff46d98f3d517d0bf086571e05c18'
                       }
                     ],
-                    "access": {
-                      "view": "world",
-                      "download": "world"
+                    access: {
+                      view: 'world',
+                      download: 'world'
                     },
-                    "administrative": {
-                      "publish": true,
-                      "sdrPreserve": true,
-                      "shelve": true
+                    administrative: {
+                      publish: true,
+                      sdrPreserve: true,
+                      shelve: true
                     },
-                    "presentation": {
-                      "height": 4580,
-                      "width": 5939
+                    presentation: {
+                      height: 4580,
+                      width: 5939
                     }
                   },
                   {
-                    "type": "#{Cocina::Models::ObjectType.file}",
-                    "externalIdentifier": "druid:cs178jh7817/gw177fc7976_05_0001.gif",
-                    "label": "gw177fc7976_05_0001.gif",
-                    "filename": "gw177fc7976_05_0001.gif",
-                    "size": 4128877,
-                    "version": 1,
-                    "hasMimeType": "image/gif",
-                    "use": "derivative",
-                    "hasMessageDigests": [
+                    type: Cocina::Models::ObjectType.file,
+                    externalIdentifier: 'druid:cs178jh7817/gw177fc7976_05_0001.gif',
+                    label: 'gw177fc7976_05_0001.gif',
+                    filename: 'gw177fc7976_05_0001.gif',
+                    size: 4_128_877,
+                    version: 1,
+                    hasMimeType: 'image/gif',
+                    use: 'derivative',
+                    hasMessageDigests: [
                       {
-                        "type": "sha1",
-                        "digest": "61940d4fad097cba98a3e9dd9f12a90dde0be1ac"
+                        type: 'sha1',
+                        digest: '61940d4fad097cba98a3e9dd9f12a90dde0be1ac'
                       },
                       {
-                        "type": "md5",
-                        "digest": "406d5d80fdd9ecc0352d339badb4a8fb"
+                        type: 'md5',
+                        digest: '406d5d80fdd9ecc0352d339badb4a8fb'
                       }
                     ],
-                    "access": {
-                      "view": "dark",
-                      "download": "none"
+                    access: {
+                      view: 'dark',
+                      download: 'none'
                     },
-                    "administrative": {
-                      "publish": false,
-                      "sdrPreserve": false,
-                      "shelve": false
+                    administrative: {
+                      publish: false,
+                      sdrPreserve: false,
+                      shelve: false
                     },
-                    "presentation": {
-                      "height": 4580,
-                      "width": 5939
+                    presentation: {
+                      height: 4580,
+                      width: 5939
                     }
                   },
                   {
-                    "type": "#{Cocina::Models::ObjectType.file}",
-                    "externalIdentifier": "druid:cs178jh7817/gw177fc7976_00_0001.tif",
-                    "label": "gw177fc7976_00_0001.tif",
-                    "filename": "gw177fc7976_00_0001.tif",
-                    "size": 81630420,
-                    "version": 1,
-                    "hasMimeType": "image/tiff",
-                    "hasMessageDigests": [
+                    type: Cocina::Models::ObjectType.file,
+                    externalIdentifier: 'druid:cs178jh7817/gw177fc7976_00_0001.tif',
+                    label: 'gw177fc7976_00_0001.tif',
+                    filename: 'gw177fc7976_00_0001.tif',
+                    size: 81_630_420,
+                    version: 1,
+                    hasMimeType: 'image/tiff',
+                    hasMessageDigests: [
                       {
-                        "type": "sha1",
-                        "digest": "12586b624540031bfa3d153299160c4885c3508c"
+                        type: 'sha1',
+                        digest: '12586b624540031bfa3d153299160c4885c3508c'
                       },
                       {
-                        "type": "md5",
-                        "digest": "81ccd17bccf349581b779615e82a0366"
+                        type: 'md5',
+                        digest: '81ccd17bccf349581b779615e82a0366'
                       }
                     ],
-                    "access": {
-                      "view": "dark",
-                      "download": "none"
+                    access: {
+                      view: 'dark',
+                      download: 'none'
                     },
-                    "administrative": {
-                      "publish": false,
-                      "sdrPreserve": true,
-                      "shelve": false
+                    administrative: {
+                      publish: false,
+                      sdrPreserve: true,
+                      shelve: false
                     },
-                    "presentation": {
-                      "height": 4580,
-                      "width": 5939
+                    presentation: {
+                      height: 4580,
+                      width: 5939
                     }
                   },
                   {
-                    "type": "#{Cocina::Models::ObjectType.file}",
-                    "externalIdentifier": "druid:cs178jh7817/gw177fc7976_00_0002.tif",
-                    "label": "gw177fc7976_00_0002.tif",
-                    "filename": "gw177fc7976_00_0002.tif",
-                    "size": 81630420,
-                    "version": 1,
-                    "hasMimeType": "image/tiff",
-                    "hasMessageDigests": [
+                    type: Cocina::Models::ObjectType.file,
+                    externalIdentifier: 'druid:cs178jh7817/gw177fc7976_00_0002.tif',
+                    label: 'gw177fc7976_00_0002.tif',
+                    filename: 'gw177fc7976_00_0002.tif',
+                    size: 81_630_420,
+                    version: 1,
+                    hasMimeType: 'image/tiff',
+                    hasMessageDigests: [
                       {
-                        "type": "sha1",
-                        "digest": "12586b624540031bfa3d153299160c4885c3508c"
+                        type: 'sha1',
+                        digest: '12586b624540031bfa3d153299160c4885c3508c'
                       },
                       {
-                        "type": "md5",
-                        "digest": "81ccd17bccf349581b779615e82a0366"
+                        type: 'md5',
+                        digest: '81ccd17bccf349581b779615e82a0366'
                       }
                     ],
-                    "access": {
-                      "view": "dark",
-                      "download": "none"
+                    access: {
+                      view: 'dark',
+                      download: 'none'
                     },
-                    "administrative": {
-                      "publish": false,
-                      "sdrPreserve": true,
-                      "shelve": false
+                    administrative: {
+                      publish: false,
+                      sdrPreserve: true,
+                      shelve: false
                     },
-                    "presentation": {
-                      "height": 4580,
-                      "width": 5939
+                    presentation: {
+                      height: 4580,
+                      width: 5939
                     }
                   }
                 ]
               }
             }
           ]
-        JSON
+        }
       end
 
       it 'has the fields used by argo' do
@@ -199,7 +184,7 @@ RSpec.describe ContentMetadataIndexer do
     end
 
     context 'when the object contains no file_sets' do
-      let(:structural) { '' }
+      let(:structural) { {} }
 
       it 'has the fields used by argo' do
         expect(doc).to include(

--- a/spec/indexers/data_indexer_spec.rb
+++ b/spec/indexers/data_indexer_spec.rb
@@ -4,18 +4,13 @@ require 'rails_helper'
 
 RSpec.describe DataIndexer do
   let(:cocina) do
-    dro = Cocina::Models::DRO.new(externalIdentifier: 'druid:xx999xx9999',
-                                  type: Cocina::Models::ObjectType.map,
-                                  label: 'test label',
-                                  version: 4,
-                                  description: {
-                                    title: [{ value: 'test label' }],
-                                    purl: 'https://purl.stanford.edu/xx999xx9999'
-                                  },
-                                  access: {},
-                                  administrative: { hasAdminPolicy: 'druid:vv888vv8888' },
-                                  structural: structural,
-                                  identification: { sourceId: 'sul:1234' })
+    dro = build(
+      :dro,
+      id: 'druid:xx999xx9999',
+      admin_policy_id: 'druid:vv888vv8888',
+      label: 'item label',
+      version: 4
+    ).new(structural: structural)
     Cocina::Models.with_metadata(dro, 'abc123', created: DateTime.parse('Wed, 01 Jan 2020 12:00:01 GMT'),
                                                 modified: DateTime.parse('Thu, 04 Mar 2021 23:05:34 GMT'))
   end
@@ -39,7 +34,7 @@ RSpec.describe DataIndexer do
 
       it 'makes a solr doc' do
         expect(doc).to eq(
-          'obj_label_tesim' => 'test label',
+          'obj_label_tesim' => 'item label',
           'current_version_isi' => 4,
           'milestones_ssim' => %w[foo bar],
           'has_constituents_ssim' => nil,
@@ -60,7 +55,7 @@ RSpec.describe DataIndexer do
 
       it 'makes a solr doc' do
         expect(doc).to eq(
-          'obj_label_tesim' => 'test label',
+          'obj_label_tesim' => 'item label',
           'current_version_isi' => 4,
           'milestones_ssim' => %w[foo bar],
           'has_model_ssim' => 'info:fedora/afmodel:Dor_Item',
@@ -81,7 +76,7 @@ RSpec.describe DataIndexer do
 
       it 'makes a solr doc' do
         expect(doc).to eq(
-          'obj_label_tesim' => 'test label',
+          'obj_label_tesim' => 'item label',
           'current_version_isi' => 4,
           'milestones_ssim' => %w[foo bar],
           'has_constituents_ssim' => ['druid:bb777bb7777', 'druid:dd666dd6666'],

--- a/spec/indexers/default_object_rights_indexer_spec.rb
+++ b/spec/indexers/default_object_rights_indexer_spec.rb
@@ -3,23 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe DefaultObjectRightsIndexer do
-  let(:cocina) do
-    Cocina::Models.build(
-      {
-        label: 'The APO',
-        version: 1,
-        type: Cocina::Models::ObjectType.admin_policy,
-        externalIdentifier: 'druid:cb123cd4567',
-        administrative: {
-          hasAdminPolicy: 'druid:hv992ry2431',
-          hasAgreement: 'druid:bb033gt0615',
-          accessTemplate: {
-            useAndReproductionStatement: 'Rights are owned by Stanford University Libraries.',
-            copyright: 'Additional copyright info',
-            view: 'location-based',
-            download: 'location-based',
-            location: 'spec'
-          }
+  let(:cocina_apo) do
+    build(:admin_policy, id: 'druid:bb123cd4567').new(
+      administrative: {
+        hasAdminPolicy: 'druid:hv992ry2431',
+        hasAgreement: 'druid:bb033gt0615',
+        accessTemplate: {
+          useAndReproductionStatement: 'Rights are owned by Stanford University Libraries.',
+          copyright: 'Additional copyright info',
+          view: 'location-based',
+          download: 'location-based',
+          location: 'spec'
         }
       }
     )
@@ -29,7 +23,7 @@ RSpec.describe DefaultObjectRightsIndexer do
     let(:indexer) do
       CompositeIndexer.new(
         described_class
-      ).new(id: 'druid:ab123cd4567', cocina: cocina)
+      ).new(id: 'druid:bb123cd4567', cocina: cocina_apo)
     end
     let(:doc) { indexer.to_solr }
 

--- a/spec/indexers/descriptive_metadata/contributor_spec.rb
+++ b/spec/indexers/descriptive_metadata/contributor_spec.rb
@@ -5,71 +5,13 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
   end
 
   describe 'primary contributor mappings from Cocina to Solr sw_author_tesim' do

--- a/spec/indexers/descriptive_metadata/event_contributor_publisher_spec.rb
+++ b/spec/indexers/descriptive_metadata/event_contributor_publisher_spec.rb
@@ -5,71 +5,13 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
   end
 
   describe 'publisher mappings from Cocina to Solr originInfo_publisher_tesim' do

--- a/spec/indexers/descriptive_metadata/event_date_creation_spec.rb
+++ b/spec/indexers/descriptive_metadata/event_date_creation_spec.rb
@@ -5,71 +5,13 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
   end
 
   describe 'date mappings from Cocina to Solr originInfo_date_created_tesim' do

--- a/spec/indexers/descriptive_metadata/event_place_spec.rb
+++ b/spec/indexers/descriptive_metadata/event_place_spec.rb
@@ -5,71 +5,13 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
   end
 
   describe 'place mappings from Cocina to Solr originInfo_place_placeTerm_tesim' do

--- a/spec/indexers/descriptive_metadata/format_spec.rb
+++ b/spec/indexers/descriptive_metadata/format_spec.rb
@@ -5,71 +5,13 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
   end
 
   describe 'form/genre mappings from Cocina to Solr sw_format_ssim' do

--- a/spec/indexers/descriptive_metadata/genre_spec.rb
+++ b/spec/indexers/descriptive_metadata/genre_spec.rb
@@ -5,72 +5,14 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
-  end
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
+  end
 
   describe 'genre mappings from Cocina to Solr sw_genre_ssim' do
     context 'when single genre' do

--- a/spec/indexers/descriptive_metadata/language_spec.rb
+++ b/spec/indexers/descriptive_metadata/language_spec.rb
@@ -5,71 +5,13 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",#{'        '}
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
   end
 
   describe 'language mappings from Cocina to Solr sw_language_ssim' do

--- a/spec/indexers/descriptive_metadata/pub_year_1e_spec.rb
+++ b/spec/indexers/descriptive_metadata/pub_year_1e_spec.rb
@@ -5,72 +5,14 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-      	"type": "#{Cocina::Models::ObjectType.image}",
-      	"externalIdentifier": "druid:qy781dy0220",
-      	"label": "SUL Logo for forebrain",
-      	"version": 1,
-      	"access": {
-      		"view": "world",
-      		"copyright": "This work is copyrighted by the creator.",
-      		"download": "world",
-      		"useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-      	},
-      	"administrative": {
-      		"hasAdminPolicy": "druid:zx485kb6348"
-      	},
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-      	"identification": {
-      		"sourceId": "hydrus:object-6"
-      	},
-      	"structural": {
-      		"contains": [{
-      			"type": "#{Cocina::Models::FileSetType.file}",
-      			"externalIdentifier": "qy781dy0220_1",
-      			"label": "qy781dy0220_1",
-      			"version": 1,
-      			"structural": {
-      				"contains": [{
-      					"type": "#{Cocina::Models::ObjectType.file}",
-      					"externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-      					"label": "sul-logo.png",
-      					"filename": "sul-logo.png",
-      					"size": 19823,
-      					"version": 1,
-      					"hasMimeType": "image/png",
-      					"hasMessageDigests": [{
-      							"type": "sha1",
-      							"digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-      						},
-      						{
-      							"type": "md5",
-      							"digest": "7142ce948827c16120cc9e19b05acd49"
-      						}
-      					],
-      					"access": {
-      						"view": "world",
-      						"download": "world"
-      					},
-      					"administrative": {
-      						"publish": true,
-      						"sdrPreserve": true,
-      						"shelve": true
-      					}
-      				}]
-      			}
-      		}],
-      		"isMemberOf": [
-      			"druid:nb022qg2431"
-      		]
-      	}
-      }
-    JSON
-  end
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
+  end
 
   describe 'publication year mappings from Cocina to Solr sw_pub_date_facet_ssi' do
     # Choose single date from selected event

--- a/spec/indexers/descriptive_metadata/pub_year_spec.rb
+++ b/spec/indexers/descriptive_metadata/pub_year_spec.rb
@@ -5,72 +5,14 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-      	"externalIdentifier": "druid:qy781dy0220",
-      	"label": "SUL Logo for forebrain",
-      	"version": 1,
-      	"access": {
-      		"view": "world",
-      		"copyright": "This work is copyrighted by the creator.",
-      		"download": "world",
-      		"useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-      	},
-      	"administrative": {
-      		"hasAdminPolicy": "druid:zx485kb6348"
-      	},
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-      	"identification": {
-      		"sourceId": "hydrus:object-6"
-      	},
-      	"structural": {
-      		"contains": [{
-      			"type": "#{Cocina::Models::FileSetType.file}",
-      			"externalIdentifier": "qy781dy0220_1",
-      			"label": "qy781dy0220_1",
-      			"version": 1,
-      			"structural": {
-      				"contains": [{
-      					"type": "#{Cocina::Models::ObjectType.file}",
-      					"externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-      					"label": "sul-logo.png",
-      					"filename": "sul-logo.png",
-      					"size": 19823,
-      					"version": 1,
-      					"hasMimeType": "image/png",
-      					"hasMessageDigests": [{
-      							"type": "sha1",
-      							"digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-      						},
-      						{
-      							"type": "md5",
-      							"digest": "7142ce948827c16120cc9e19b05acd49"
-      						}
-      					],
-      					"access": {
-      						"view": "world",
-      						"download": "world"
-      					},
-      					"administrative": {
-      						"publish": true,
-      						"sdrPreserve": true,
-      						"shelve": true
-      					}
-      				}]
-      			}
-      		}],
-      		"isMemberOf": [
-      			"druid:nb022qg2431"
-      		]
-      	}
-      }
-    JSON
-  end
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
+  end
 
   describe 'publication year mappings from Cocina to Solr sw_pub_date_facet_ssi' do
     context 'when event has date.type publication and date.status primary' do

--- a/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_geographic_spec.rb
@@ -5,72 +5,14 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
-  end
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
+  end
 
   describe 'subject mappings from Cocina to Solr sw_subject_geographic_ssim' do
     context 'when single geographic subject' do

--- a/spec/indexers/descriptive_metadata/subject_temporal_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_temporal_spec.rb
@@ -5,72 +5,14 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
-  end
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
+  end
 
   describe 'subject mappings from Cocina to Solr sw_subject_temporal_ssim' do
     context 'when single temporal subject' do

--- a/spec/indexers/descriptive_metadata/subject_topic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_topic_spec.rb
@@ -5,72 +5,14 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
-  end
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
+  end
 
   describe 'subject mappings from Cocina to Solr topic_ssim (facet) and topic_tesim (search)' do
     # topic_tesim: subject/topic

--- a/spec/indexers/descriptive_metadata/title_spec.rb
+++ b/spec/indexers/descriptive_metadata/title_spec.rb
@@ -5,72 +5,14 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
-  end
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
+  end
 
   describe 'title mappings from Cocina to Solr sw_display_title_tesim' do
     describe 'single untyped title' do

--- a/spec/indexers/descriptive_metadata/type_of_resource_spec.rb
+++ b/spec/indexers/descriptive_metadata/type_of_resource_spec.rb
@@ -5,71 +5,13 @@ require 'rails_helper'
 RSpec.describe DescriptiveMetadataIndexer do
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-        "type": "#{Cocina::Models::ObjectType.image}",
-        "externalIdentifier": "druid:qy781dy0220",
-        "label": "SUL Logo for forebrain",
-        "version": 1,
-        "access": {
-          "view": "world",
-          "copyright": "This work is copyrighted by the creator.",
-          "download": "world",
-          "useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-        },
-        "administrative": {
-          "hasAdminPolicy": "druid:zx485kb6348"
-        },
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-        "identification": {
-          "sourceId": "hydrus:object-6"
-        },
-        "structural": {
-          "contains": [{
-            "type": "#{Cocina::Models::FileSetType.file}",
-            "externalIdentifier": "qy781dy0220_1",
-            "label": "qy781dy0220_1",
-            "version": 1,
-            "structural": {
-              "contains": [{
-                "type": "#{Cocina::Models::ObjectType.file}",
-                "externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-                "label": "sul-logo.png",
-                "filename": "sul-logo.png",
-                "size": 19823,
-                "version": 1,
-                "hasMimeType": "image/png",
-                "hasMessageDigests": [{
-                    "type": "sha1",
-                    "digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-                  },
-                  {
-                    "type": "md5",
-                    "digest": "7142ce948827c16120cc9e19b05acd49"
-                  }
-                ],
-                "access": {
-                  "view": "world",
-                  "download": "world"
-                },
-                "administrative": {
-                  "publish": true,
-                  "sdrPreserve": true,
-                  "shelve": true
-                }
-              }]
-            }
-          }],
-          "isMemberOf": [
-            "druid:nb022qg2431"
-          ]
-        }
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge(purl: "https://purl.stanford.edu/#{bare_druid}")
+    )
   end
 
   describe 'form mappings from Cocina to Solr mods_typeOfResource_ssim' do

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -7,71 +7,13 @@ RSpec.describe DescriptiveMetadataIndexer do
   # https://argo.stanford.edu/view/sf449my9678
   subject(:indexer) { described_class.new(cocina: cocina) }
 
-  let(:cocina) { Cocina::Models.build(JSON.parse(json)) }
+  let(:bare_druid) { 'qy781dy0220' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:doc) { indexer.to_solr }
-  let(:json) do
-    <<~JSON
-      {
-        "cocinaVersion": "0.0.1",
-      	"type": "#{Cocina::Models::ObjectType.image}",
-      	"externalIdentifier": "druid:qy781dy0220",
-      	"label": "SUL Logo for forebrain",
-      	"version": 1,
-      	"access": {
-      		"view": "world",
-      		"copyright": "This work is copyrighted by the creator.",
-      		"download": "world",
-      		"useAndReproductionStatement": "This document is available only to the Stanford faculty, staff and student community."
-      	},
-      	"administrative": {
-      		"hasAdminPolicy": "druid:zx485kb6348"
-      	},
-        "description": #{JSON.generate(description.merge(purl: 'https://purl.stanford.edu/qy781dy0220'))},
-      	"identification": {
-      		"sourceId": "hydrus:object-6"
-      	},
-      	"structural": {
-      		"contains": [{
-      			"type": "#{Cocina::Models::FileSetType.file}",
-      			"externalIdentifier": "qy781dy0220_1",
-      			"label": "qy781dy0220_1",
-      			"version": 1,
-      			"structural": {
-      				"contains": [{
-      					"type": "#{Cocina::Models::ObjectType.file}",
-      					"externalIdentifier": "druid:qy781dy0220/sul-logo.png",
-      					"label": "sul-logo.png",
-      					"filename": "sul-logo.png",
-      					"size": 19823,
-      					"version": 1,
-      					"hasMimeType": "image/png",
-      					"hasMessageDigests": [{
-      							"type": "sha1",
-      							"digest": "b5f3221455c8994afb85214576bc2905d6b15418"
-      						},
-      						{
-      							"type": "md5",
-      							"digest": "7142ce948827c16120cc9e19b05acd49"
-      						}
-      					],
-      					"access": {
-      						"view": "world",
-      						"download": "world"
-      					},
-      					"administrative": {
-      						"publish": true,
-      						"sdrPreserve": true,
-      						"shelve": true
-      					}
-      				}]
-      			}
-      		}],
-      		"isMemberOf": [
-      			"druid:nb022qg2431"
-      		]
-      	}
-      }
-    JSON
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      description: description.merge({ purl: "https://purl.stanford.edu/#{bare_druid}" })
+    )
   end
   let(:description) do
     {

--- a/spec/indexers/embargo_metadata_indexer_spec.rb
+++ b/spec/indexers/embargo_metadata_indexer_spec.rb
@@ -3,43 +3,27 @@
 require 'rails_helper'
 
 RSpec.describe EmbargoMetadataIndexer do
-  let(:apo_id) { 'druid:gf999hb9999' }
   let(:druid) { 'druid:zz666yy9999' }
   let(:release_date) { '2024-06-06' }
-  let(:cocina) do
-    Cocina::Models.build(
-      {
-        type: Cocina::Models::ObjectType.object,
-        externalIdentifier: druid,
-        label: 'testing embargo indexing',
-        version: 1,
-        access: {
+  let(:cocina_item) do
+    build(:dro, id: druid).new(
+      access: {
+        view: 'world',
+        download: 'none',
+        copyright: 'some student',
+        useAndReproductionStatement: 'restricted until embargo lifted',
+        embargo: {
+          releaseDate: release_date,
           view: 'world',
-          download: 'none',
-          copyright: 'some student',
-          useAndReproductionStatement: 'restricted until embargo lifted',
-          embargo: {
-            releaseDate: release_date,
-            view: 'world',
-            download: 'world',
-            useAndReproductionStatement: 'freedom reigns'
-          }
-        },
-        administrative: {
-          hasAdminPolicy: apo_id
-        },
-        description: {
-          title: [{ value: 'embargo indexing object' }],
-          purl: 'https://purl.stanford.edu/zz666yy9999'
-        },
-        identification: { sourceId: 'sul:1234' },
-        structural: {}
+          download: 'world',
+          useAndReproductionStatement: 'freedom reigns'
+        }
       }
     )
   end
 
   let(:indexer) do
-    described_class.new(cocina: cocina)
+    described_class.new(cocina: cocina_item)
   end
 
   describe '#to_solr' do
@@ -68,31 +52,7 @@ RSpec.describe EmbargoMetadataIndexer do
     end
 
     context 'when there is no embargo' do
-      let(:cocina) do
-        Cocina::Models.build(
-          {
-            type: Cocina::Models::ObjectType.object,
-            externalIdentifier: druid,
-            label: 'testing embargo indexing',
-            version: 1,
-            access: {
-              view: 'world',
-              download: 'none',
-              copyright: 'some student',
-              useAndReproductionStatement: 'restricted until embargo lifted'
-            },
-            administrative: {
-              hasAdminPolicy: apo_id
-            },
-            description: {
-              title: [{ value: 'embargo indexing object' }],
-              purl: 'https://purl.stanford.edu/zz666yy9999'
-            },
-            identification: { sourceId: 'sul:1234' },
-            structural: {}
-          }
-        )
-      end
+      let(:cocina_item) { build(:dro, id: druid) }
 
       it 'Solr doc does not have embargo fields' do
         expect(doc).to eq({})

--- a/spec/indexers/identifiable_indexer_spec.rb
+++ b/spec/indexers/identifiable_indexer_spec.rb
@@ -5,28 +5,9 @@ require 'rails_helper'
 RSpec.describe IdentifiableIndexer do
   let(:druid) { 'druid:rt923jk3422' }
   let(:apo_id) { 'druid:bd999bd9999' }
-  let(:cocina) do
-    Cocina::Models.build(
-      {
-        externalIdentifier: druid,
-        type: Cocina::Models::ObjectType.image,
-        version: 1,
-        label: 'testing',
-        access: {},
-        administrative: {
-          hasAdminPolicy: apo_id
-        },
-        description: {
-          title: [{ value: 'Test obj' }],
-          subject: [{ type: 'topic', value: 'word' }],
-          purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-        },
-        structural: {
-          contains: [],
-          isMemberOf: []
-        },
-        identification: identification
-      }
+  let(:cocina_item) do
+    build(:dro, id: druid, admin_policy_id: apo_id).new(
+      identification: identification
     )
   end
   let(:identification) do
@@ -37,7 +18,7 @@ RSpec.describe IdentifiableIndexer do
   end
 
   let(:indexer) do
-    described_class.new(cocina: cocina)
+    described_class.new(cocina: cocina_item)
   end
 
   before do
@@ -53,33 +34,11 @@ RSpec.describe IdentifiableIndexer do
   describe '#to_solr' do
     let(:doc) { indexer.to_solr }
     let(:mock_rel_druid) { 'druid:qf999gg9999' }
-
-    let(:related) do
-      Cocina::Models.build(
-        {
-          externalIdentifier: apo_id,
-          type: Cocina::Models::ObjectType.admin_policy,
-          version: 1,
-          label: 'testing',
-          administrative: {
-            hasAdminPolicy: apo_id,
-            hasAgreement: 'druid:bb033gt0615',
-            accessTemplate: { view: 'world', download: 'world' }
-          },
-          description: {
-            title: [{ value: 'Test object' }],
-            purl: "https://purl.stanford.edu/#{apo_id.delete_prefix('druid:')}"
-          }
-        }
-      )
-    end
-    let(:object_client) do
-      instance_double(Dor::Services::Client::Object, find: related)
-    end
+    let(:related) { build(:admin_policy, id: apo_id) }
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: related) }
 
     before do
       allow(object_client).to receive_message_chain(:administrative_tags, :list).and_return([])
-
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     end
 
@@ -95,29 +54,11 @@ RSpec.describe IdentifiableIndexer do
     end
 
     context 'when APO is found' do
-      let(:related) do
-        Cocina::Models.build(
-          {
-            externalIdentifier: mock_rel_druid,
-            type: Cocina::Models::ObjectType.collection,
-            version: 1,
-            label: 'testing',
-            administrative: {
-              hasAdminPolicy: apo_id
-            },
-            access: {},
-            description: {
-              title: [{ value: 'Test object' }],
-              purl: "https://purl.stanford.edu/#{mock_rel_druid.delete_prefix('druid:')}"
-            },
-            identification: { sourceId: 'sul:1234' }
-          }
-        )
-      end
+      let(:related) { build(:collection, id: mock_rel_druid, admin_policy_id: apo_id, title: 'collection title') }
 
       it 'generates apo title fields' do
-        expect(doc[Solrizer.solr_name('apo_title', :symbol)].first).to eq 'Test object'
-        expect(doc[Solrizer.solr_name('nonhydrus_apo_title', :symbol)].first).to eq 'Test object'
+        expect(doc[Solrizer.solr_name('apo_title', :symbol)].first).to eq 'collection title'
+        expect(doc[Solrizer.solr_name('nonhydrus_apo_title', :symbol)].first).to eq 'collection title'
       end
 
       it 'indexes metadata source' do
@@ -138,27 +79,7 @@ RSpec.describe IdentifiableIndexer do
     end
 
     context 'with no identification sub-schema' do
-      let(:cocina) do
-        Cocina::Models.build(
-          {
-            externalIdentifier: druid,
-            type: Cocina::Models::ObjectType.image,
-            version: 1,
-            label: 'testing',
-            access: {},
-            administrative: {
-              hasAdminPolicy: apo_id
-            },
-            description: {
-              title: [{ value: 'Test obj' }],
-              subject: [{ type: 'topic', value: 'word' }],
-              purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-            },
-            structural: {},
-            identification: { sourceId: 'sul:1234' }
-          }
-        )
-      end
+      let(:cocina_item) { build(:dro, id: druid, admin_policy_id: apo_id) }
 
       it 'indexes metadata source' do
         # rubocop:disable Style/StringHashKeys

--- a/spec/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_indexer_spec.rb
@@ -3,28 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe IdentityMetadataIndexer do
-  let(:cocina) do
-    Cocina::Models.build({
-      externalIdentifier: 'druid:rt923jk3421',
-      type: type,
-      version: 1,
-      label: 'Squirrels of North America',
-      description: {
-        title: [{ value: 'Squirrels of North America' }],
-        purl: 'https://purl.stanford.edu/rt923jk3421'
-      },
-      access: {},
-      administrative: {
-        hasAdminPolicy: 'druid:bd999bd9999'
-      },
-      identification: identification,
-      structural: {}
-    }.with_indifferent_access)
-  end
-
-  let(:indexer) do
-    described_class.new(cocina: cocina)
-  end
+  let(:druid) { 'druid:rt923jk3421' }
+  let(:cocina_object) { build(:dro_with_metadata, type: type, id: druid).new(identification: identification) }
+  let(:indexer) { described_class.new(cocina: cocina_object) }
 
   describe '#to_solr' do
     subject(:doc) { indexer.to_solr }
@@ -83,25 +64,7 @@ RSpec.describe IdentityMetadataIndexer do
 
     context 'with a collection' do
       # Collection objects have no structural attribute
-      let(:cocina) do
-        collection = Cocina::Models.build({
-          externalIdentifier: 'druid:rt923jk3421',
-          type: type,
-          version: 1,
-          label: 'Squirrels of North America',
-          description: {
-            title: [{ value: 'Squirrels of North America' }],
-            purl: 'https://purl.stanford.edu/rt923jk3421'
-          },
-          access: {},
-          administrative: {
-            hasAdminPolicy: 'druid:bd999bd9999'
-          },
-          identification: identification
-        }.with_indifferent_access)
-        Cocina::Models.with_metadata(collection, 'abc123')
-      end
-      let(:type) { Cocina::Models::ObjectType.collection }
+      let(:cocina_object) { build(:collection_with_metadata, id: druid).new(identification: identification) }
       let(:identification) do
         {
           sourceId: 'google:STANFORD_342837261527',

--- a/spec/indexers/releasable_indexer_spec.rb
+++ b/spec/indexers/releasable_indexer_spec.rb
@@ -4,28 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ReleasableIndexer do
   let(:apo_id) { 'druid:gf999hb9999' }
-
-  let(:cocina) do
-    Cocina::Models.build(
-      {
-        externalIdentifier: 'druid:pz263ny9658',
-        type: Cocina::Models::ObjectType.image,
-        version: 1,
-        label: 'testing',
-        access: {},
-        administrative: administrative,
-        description: {
-          title: [{ value: 'Test obj' }],
-          purl: 'https://purl.stanford.edu/pz263ny9658'
-        },
-        structural: {},
-        identification: {
-          catalogLinks: [{ catalog: 'symphony', catalogRecordId: '1234', refresh: true }],
-          sourceId: 'sul:1234'
-        }
-      }
-    )
-  end
+  let(:cocina) { build(:dro).new(administrative: administrative) }
 
   describe 'to_solr' do
     let(:doc) { described_class.new(cocina: cocina, parent_collections: parent_collections).to_solr }

--- a/spec/indexers/rights_metadata_indexer_spec.rb
+++ b/spec/indexers/rights_metadata_indexer_spec.rb
@@ -14,26 +14,12 @@ RSpec.describe RightsMetadataIndexer do
     let(:access) { 'world' }
 
     let(:cocina) do
-      Cocina::Models.build(
-        {
-          externalIdentifier: 'druid:rt923jk3429',
-          type: Cocina::Models::ObjectType.collection,
-          version: 1,
-          label: 'testing',
-          access: {
-            view: access,
-            license: license,
-            copyright: 'Copyright © World Trade Organization',
-            useAndReproductionStatement: 'Official WTO documents are free for public use.'
-          },
-          administrative: {
-            hasAdminPolicy: 'druid:xx000xx0000'
-          },
-          description: {
-            title: [{ value: 'Test obj' }],
-            purl: 'https://purl.stanford.edu/rt923jk3429'
-          },
-          identification: { sourceId: 'sul:1234' }
+      build(:collection).new(
+        access: {
+          view: access,
+          license: license,
+          copyright: 'Copyright © World Trade Organization',
+          useAndReproductionStatement: 'Official WTO documents are free for public use.'
         }
       )
     end
@@ -69,23 +55,9 @@ RSpec.describe RightsMetadataIndexer do
 
   context 'with an item' do
     let(:cocina) do
-      Cocina::Models.build(
-        {
-          externalIdentifier: 'druid:rt923jk3429',
-          type: Cocina::Models::ObjectType.image,
-          version: 1,
-          label: 'testing',
-          access: access,
-          administrative: {
-            hasAdminPolicy: 'druid:xx000xx0000'
-          },
-          description: {
-            title: [{ value: 'Test obj' }],
-            purl: 'https://purl.stanford.edu/rt923jk3429'
-          },
-          structural: structural,
-          identification: { sourceId: 'sul:1234' }
-        }
+      build(:dro).new(
+        access: access,
+        structural: structural
       )
     end
     let(:structural) { {} }

--- a/spec/indexers/role_metadata_indexer_spec.rb
+++ b/spec/indexers/role_metadata_indexer_spec.rb
@@ -5,38 +5,28 @@ require 'rails_helper'
 RSpec.describe RoleMetadataIndexer do
   let(:apo_id) { 'druid:gf999hb9999' }
   let(:cocina) do
-    Cocina::Models.build(
-      {
-        externalIdentifier: apo_id,
-        type: Cocina::Models::ObjectType.admin_policy,
-        version: 1,
-        label: 'testing',
-        administrative: {
-          hasAdminPolicy: apo_id,
-          hasAgreement: 'druid:bb033gt0615',
-          roles: [
-            { name: 'dor-apo-manager',
-              members: [
-                {
-                  type: 'workgroup',
-                  identifier: 'dlss:dor-admin'
-                },
-                {
-                  type: 'workgroup',
-                  identifier: 'sdr:developer'
-                },
-                {
-                  type: 'sunetid',
-                  identifier: 'tcramer'
-                }
-              ] }
-          ],
-          accessTemplate: { view: 'world', download: 'world' }
-        },
-        description: {
-          title: [{ value: 'APO title' }],
-          purl: 'https://purl.stanford.edu/gf999hb9999'
-        }
+    build(:admin_policy, id: apo_id).new(
+      administrative: {
+        hasAdminPolicy: apo_id,
+        hasAgreement: 'druid:bb033gt0615',
+        roles: [
+          { name: 'dor-apo-manager',
+            members: [
+              {
+                type: 'workgroup',
+                identifier: 'dlss:dor-admin'
+              },
+              {
+                type: 'workgroup',
+                identifier: 'sdr:developer'
+              },
+              {
+                type: 'sunetid',
+                identifier: 'tcramer'
+              }
+            ] }
+        ],
+        accessTemplate: { view: 'world', download: 'world' }
       }
     )
   end

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -4,23 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ReindexJob do
   let(:message) { { model: model, created_at: 'Wed, 01 Jan 2021 12:58:00 GMT', modified_at: 'Wed, 03 Mar 2021 18:58:00 GMT' }.to_json }
-  let(:druid) { 'druid:bc123df4567' }
-
-  let(:model) do
-    Cocina::Models::DRO.new(externalIdentifier: druid,
-                            type: Cocina::Models::ObjectType.object,
-                            label: 'my repository object',
-                            version: 1,
-                            description: {
-                              title: [{ value: 'my repository object' }],
-                              purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-                            },
-                            access: {},
-                            administrative: { hasAdminPolicy: 'druid:xx999xx9999' },
-                            identification: { sourceId: 'sul:1234' },
-                            structural: {})
-  end
-
+  let(:model) { build(:dro) }
   let(:result) { Success(double) }
   let(:indexer) { instance_double(Indexer, reindex: true) }
 
@@ -28,7 +12,7 @@ RSpec.describe ReindexJob do
     allow(Indexer).to receive(:new).and_return(indexer)
   end
 
-  it 'updates the druid' do
+  it 'updates the index' do
     described_class.new.work(message)
     expect(indexer).to have_received(:reindex)
       .with(add_attributes: { commitWithin: 1000 }, cocina_with_metadata: Success(Cocina::Models::DROWithMetadata))

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'cocina/rspec'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/services/document_builder_spec.rb
+++ b/spec/services/document_builder_spec.rb
@@ -40,24 +40,9 @@ RSpec.describe DocumentBuilder do
 
   context 'when the model is an item' do
     let(:cocina) do
-      Cocina::Models.build(
-        {
-          type: Cocina::Models::ObjectType.object,
-          structural: {
-            isMemberOf: collections
-          },
-          label: 'Test DRO',
-          version: 1,
-          description: {
-            title: [{ value: 'Test DRO' }],
-            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-          },
-          administrative: {
-            hasAdminPolicy: 'druid:gf999hb9999'
-          },
-          access: {},
-          externalIdentifier: druid,
-          identification: { sourceId: 'sul:1234' }
+      build(:dro, id: druid).new(
+        structural: {
+          isMemberOf: collections
         }
       )
     end
@@ -72,26 +57,7 @@ RSpec.describe DocumentBuilder do
       let(:object_client) do
         instance_double(Dor::Services::Client::Object, find: related, administrative_tags: admin_tags_client)
       end
-      let(:related) do
-        Cocina::Models.build(
-          {
-            externalIdentifier: 'druid:bc999df2323',
-            type: Cocina::Models::ObjectType.collection,
-            version: 1,
-            label: 'testing',
-            administrative: {
-              hasAdminPolicy: 'druid:gf999hb9999'
-            },
-            access: {},
-            description: {
-              title: [{ value: 'Test object' }],
-              purl: 'https://purl.stanford.edu/bc999df2323'
-            },
-            identification: { sourceId: 'sul:1234' }
-          }
-        )
-      end
-
+      let(:related) { build(:collection) }
       let(:collections) { ['druid:bc999df2323'] }
 
       it { is_expected.to be_instance_of CompositeIndexer::Instance }
@@ -120,70 +86,19 @@ RSpec.describe DocumentBuilder do
   end
 
   context 'when the model is an admin policy' do
-    let(:cocina) do
-      Cocina::Models.build(
-        {
-          type: Cocina::Models::ObjectType.admin_policy,
-          label: 'Test APO',
-          version: 1,
-          administrative: {
-            hasAdminPolicy: 'druid:gf999hb9999',
-            hasAgreement: 'druid:bb033gt0615',
-            accessTemplate: { view: 'world', download: 'world' }
-          },
-          externalIdentifier: druid
-        }
-      )
-    end
+    let(:cocina) { build(:admin_policy) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is a collection' do
-    let(:cocina) do
-      Cocina::Models.build(
-        {
-          type: Cocina::Models::ObjectType.collection,
-          label: 'Test Collection',
-          version: 1,
-          description: {
-            title: [{ value: 'Test Collection' }],
-            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-          },
-          administrative: {
-            hasAdminPolicy: 'druid:gf999hb9999'
-          },
-          access: {},
-          externalIdentifier: druid,
-          identification: { sourceId: 'sul:1234' }
-        }
-      )
-    end
+    let(:cocina) { build(:collection) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
 
   context 'when the model is an agreement' do
-    let(:cocina) do
-      Cocina::Models.build(
-        {
-          type: Cocina::Models::ObjectType.agreement,
-          structural: {},
-          label: 'Test Agreement',
-          version: 1,
-          description: {
-            title: [{ value: 'Test Agreement' }],
-            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-          },
-          administrative: {
-            hasAdminPolicy: 'druid:gf999hb9999'
-          },
-          access: {},
-          externalIdentifier: druid,
-          identification: { sourceId: 'sul:1234' }
-        }
-      )
-    end
+    let(:cocina) { build(:dro, type: Cocina::Models::ObjectType.agreement) }
 
     it { is_expected.to be_instance_of CompositeIndexer::Instance }
   end
@@ -192,27 +107,7 @@ RSpec.describe DocumentBuilder do
     subject(:solr_doc) { indexer.to_solr }
 
     let(:apo_id) { 'druid:bd999bd9999' }
-
-    let(:apo) do
-      Cocina::Models.build(
-        {
-          externalIdentifier: apo_id,
-          type: Cocina::Models::ObjectType.admin_policy,
-          version: 1,
-          label: 'testing',
-          administrative: {
-            hasAdminPolicy: 'druid:xx000xx0000',
-            hasAgreement: 'druid:bb033gt0615',
-            accessTemplate: { view: 'world', download: 'world' }
-          },
-          description: {
-            title: [{ value: 'APO title' }],
-            purl: 'https://purl.stanford.edu/bd999bd9999'
-          }
-        }
-      )
-    end
-
+    let(:apo) { build(:admin_policy, id: apo_id) }
     let(:apo_object_client) { instance_double(Dor::Services::Client::Object, find: apo) }
 
     before do
@@ -222,60 +117,45 @@ RSpec.describe DocumentBuilder do
 
     context 'when the model is an item' do
       let(:cocina) do
-        Cocina::Models.build(
-          {
-            externalIdentifier: druid,
-            type: Cocina::Models::ObjectType.image,
-            version: 1,
-            label: 'testing',
-            access: {},
-            administrative: {
-              hasAdminPolicy: apo_id
-            },
-            description: {
-              title: [{ value: 'Test obj' }],
-              purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}",
-              subject: [{ type: 'topic', value: 'word' }],
-              event: [
-                {
-                  type: 'creation',
-                  date: [
-                    {
-                      value: '2021-01-01',
-                      status: 'primary',
-                      encoding: {
-                        code: 'w3cdtf'
-                      },
-                      type: 'creation'
-                    }
-                  ]
-                },
-                {
-                  type: 'publication',
-                  location: [
-                    {
-                      value: 'Moskva'
-                    }
-                  ],
-                  contributor: [
-                    {
-                      name: [
-                        {
-                          value: 'Izdatelʹstvo "Vesʹ Mir"'
-                        }
-                      ],
-                      type: 'organization',
-                      role: [{ value: 'publisher' }]
-                    }
-                  ]
-                }
-              ]
-            },
-            structural: {},
-            identification: {
-              catalogLinks: [{ catalog: 'symphony', catalogRecordId: '1234', refresh: true }],
-              sourceId: 'sul:1234'
-            }
+        build(:dro, id: druid, admin_policy_id: apo_id).new(
+          description: {
+            title: [{ value: 'Test obj' }],
+            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}",
+            subject: [{ type: 'topic', value: 'word' }],
+            event: [
+              {
+                type: 'creation',
+                date: [
+                  {
+                    value: '2021-01-01',
+                    status: 'primary',
+                    encoding: {
+                      code: 'w3cdtf'
+                    },
+                    type: 'creation'
+                  }
+                ]
+              },
+              {
+                type: 'publication',
+                location: [
+                  {
+                    value: 'Moskva'
+                  }
+                ],
+                contributor: [
+                  {
+                    name: [
+                      {
+                        value: 'Izdatelʹstvo "Vesʹ Mir"'
+                      }
+                    ],
+                    type: 'organization',
+                    role: [{ value: 'publisher' }]
+                  }
+                ]
+              }
+            ]
           }
         )
       end
@@ -291,23 +171,12 @@ RSpec.describe DocumentBuilder do
 
     context 'when the model is an admin policy' do
       let(:model) { Dor::AdminPolicyObject.new(pid: druid) }
-
       let(:cocina) do
-        Cocina::Models.build(
-          {
-            externalIdentifier: druid,
-            type: Cocina::Models::ObjectType.admin_policy,
-            version: 1,
-            label: 'testing',
-            administrative: {
-              hasAdminPolicy: apo_id,
-              hasAgreement: 'druid:bb033gt0615',
-              accessTemplate: { view: 'world', download: 'world' }
-            },
-            description: {
-              title: [{ value: 'Test obj' }],
-              purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-            }
+        build(:admin_policy, id: druid).new(
+          administrative: {
+            hasAdminPolicy: apo_id,
+            hasAgreement: 'druid:bb033gt0615',
+            accessTemplate: { view: 'world', download: 'world' }
           }
         )
       end
@@ -317,23 +186,12 @@ RSpec.describe DocumentBuilder do
 
     context 'when the model is a hydrus apo' do
       let(:model) { Hydrus::AdminPolicyObject.new(pid: druid) }
-
       let(:cocina) do
-        Cocina::Models.build(
-          {
-            externalIdentifier: druid,
-            type: Cocina::Models::ObjectType.admin_policy,
-            version: 1,
-            label: 'testing',
-            administrative: {
-              hasAdminPolicy: apo_id,
-              hasAgreement: 'druid:bb033gt0615',
-              accessTemplate: { view: 'world', download: 'world' }
-            },
-            description: {
-              title: [{ value: 'Test obj' }],
-              purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-            }
+        build(:admin_policy, id: druid).new(
+          administrative: {
+            hasAdminPolicy: apo_id,
+            hasAgreement: 'druid:bb033gt0615',
+            accessTemplate: { view: 'world', download: 'world' }
           }
         )
       end


### PR DESCRIPTION
## Why was this change made? 🤔

to reduce boilerplate in our specs.

Closes #831

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



