### PR TITLE
Add a wait-port command for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ Publish:
 ```
 docker push suldlss/dor-indexing-app:latest
 ```
+
+#### Note
+When running the workers, you need to ensure that rabbitmq is up first. You can do this by running:
+
+```
+sh -c "docker/wait-port.sh rabbitmq 5672 ; bin/rake sneakers:run"
+```

--- a/docker/wait-port.sh
+++ b/docker/wait-port.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This is a utility that waits for a port to be accessable. It depends on netcat (nc)
+# Example:
+#   ./wait-port.sh localhost 8080
+#
+while ! nc -z $1 $2 ; do
+  sleep 1 ;
+  echo waiting for $1:$2
+done


### PR DESCRIPTION
## Why was this change made? 🤔
When running the workers, you need to ensure that rabbitmq is up first


## How was this change tested? 🤨
Tested in Argo's docker-compose

