### PR TITLE
Remove unused dry config from rails_helper.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,9 +40,6 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.include(Dry::Monads[:result])
-  config.include(Dry::Monads[:maybe])
-
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
## Why was this change made? 🤔
It isn't used anymore.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



