### PR TITLE
Use trie-dates for released_to_* for faster range queries

### DIFF
--- a/app/indexers/releasable_indexer.rb
+++ b/app/indexers/releasable_indexer.rb
@@ -15,8 +15,8 @@ class ReleasableIndexer
 
     {
       'released_to_ssim' => tags.map(&:to).uniq,
-      'released_to_searchworks_dtsi' => searchworks_release_date,
-      'released_to_earthworks_dtsi' => earthworks_release_date
+      'released_to_searchworks_dttsi' => searchworks_release_date,
+      'released_to_earthworks_dttsi' => earthworks_release_date
     }.compact
   end
 

--- a/spec/indexers/releasable_indexer_spec.rb
+++ b/spec/indexers/releasable_indexer_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe ReleasableIndexer do
           # rubocop:disable Style/StringHashKeys
           expect(doc).to eq(
             'released_to_ssim' => %w[Searchworks Earthworks],
-            'released_to_earthworks_dtsi' => '2016-11-16T22:52:35Z',
-            'released_to_searchworks_dtsi' => '2021-05-12T21:05:21Z'
+            'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z',
+            'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z'
           )
           # rubocop:enable Style/StringHashKeys
         end


### PR DESCRIPTION
## Why was this change made? 🤔
Trie-dates are already used for many other date fields in the Argo index. They are faster for doing range queries which will support the type of faceting we intend to use this field for.


## How was this change tested? 🤨
Test suite.



