### PR TITLE
Guard against subjects with no value

### DIFF
--- a/app/services/topic_builder.rb
+++ b/app/services/topic_builder.rb
@@ -49,7 +49,7 @@ class TopicBuilder
       value.parallelValue.flat_map { |topic| flat_topic(topic) }
     elsif remove_trailing_punctuation?
       # comma, semicolon, and backslash are dropped
-      Array(value.value.sub(/[ ,;\\]+$/, ''))
+      Array(value.value&.sub(/[ ,;\\]+$/, ''))
     else
       Array(value.value)
     end

--- a/spec/indexers/descriptive_metadata/subject_topic_spec.rb
+++ b/spec/indexers/descriptive_metadata/subject_topic_spec.rb
@@ -985,5 +985,30 @@ RSpec.describe DescriptiveMetadataIndexer do
         expect(doc).to include('topic_tesim' => ['Cats.'])
       end
     end
+
+    context 'when subject is missing a value' do
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'Title'
+            }
+          ],
+          subject: [
+            {
+              value: 'Cats.',
+              type: 'topic'
+            },
+            {
+              type: 'topic'
+            }
+          ]
+        }
+      end
+
+      it 'ignores subjects that are missing a value' do
+        expect(doc).to include('topic_tesim' => ['Cats.'])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

While we don't want Cocina to have subjects that have no value, we also don't want dor_indexing_app to blow up when it is sent them. This change will simply not try to remove punctuation from subjects that lack a value.

Do we know if Cocina validation should have trapped these earlier?

Fixes #882

## How was this change tested? 🤨

Added a new unit test, and ran all of them.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡
