### PR TITLE
desc_metadata_indexer: avoid error when genre value is nil

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -112,7 +112,7 @@ class DescriptiveMetadataIndexer
 
     return resource_type_formats if resource_type_formats == ['Book']
 
-    genre_formats = flat_forms_for('genre').map { |form| form.value.capitalize }.uniq
+    genre_formats = flat_forms_for('genre').map { |form| form.value&.capitalize }.uniq
 
     (resource_type_formats + genre_formats).presence
   end

--- a/spec/indexers/descriptive_metadata/genre_spec.rb
+++ b/spec/indexers/descriptive_metadata/genre_spec.rb
@@ -203,5 +203,31 @@ RSpec.describe DescriptiveMetadataIndexer do
         expect(doc).to include('sw_genre_ssim' => ['technical report', 'Technical report'])
       end
     end
+
+    context 'when genre has no value' do
+      # from zv340pg2457
+      let(:description) do
+        {
+          title: [
+            {
+              value: 'title'
+            }
+          ],
+          form: [
+            {
+              type: 'genre',
+              source: {
+                code: 'aat',
+                uri: 'http://vocab.getty.edu/aat/'
+              }
+            }
+          ]
+        }
+      end
+
+      it 'does not throw error' do
+        expect(doc).to include('sw_genre_ssim' => [''])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

To address https://app.honeybadger.io/projects/49898/faults/87288421

While we don't want Cocina to have genres that have no value, we also don't want dor_indexing_app to blow up when it is sent them. This change will simply not try to capitalize a genre that lacks a value.

@arcadiafalcone not sure how to re-index all the affected items ...

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



