### PR TITLE
Handle UnexpectedResponse in rolling indexer

### DIFF
--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -19,6 +19,8 @@ Daemons.run_proc('rolling index') do
         Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
         # Clean up cruft in QA and stage
         Indexer.delete(solr: solr_conn, identifier: identifier) if ['stage', 'qa'].include?(ENV['HONEYBADGER_ENV'])
+      rescue Dor::Services::Client::UnexpectedResponse
+        Honeybadger.notify('Unexpected response from Dor Services App for ', { druid: identifier })
       end
     end
     sleep(5) # This was just a wild guess.  We can turn this up/down as necessary.


### PR DESCRIPTION
## Why was this change made? 🤔
Rolling indexer dies when receiving a Dor::Services::Client::UnexpectedResponse (which can happen with cocina validation errors).


## How was this change tested? 🤨
Unit, deployed to stage.


⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



