### PR TITLE
Adding identifier to rolling indexer message

### DIFF
--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -20,7 +20,7 @@ Daemons.run_proc('rolling index') do
         # Clean up cruft in QA and stage
         Indexer.delete(solr: solr_conn, identifier: identifier) if ['stage', 'qa'].include?(ENV['HONEYBADGER_ENV'])
       rescue Dor::Services::Client::UnexpectedResponse
-        Honeybadger.notify('Unexpected response from Dor Services App for ', { druid: identifier })
+        Honeybadger.notify('Unexpected response from Dor Services App.', { druid: identifier })
       end
     end
     sleep(5) # This was just a wild guess.  We can turn this up/down as necessary.


### PR DESCRIPTION
## Why was this change made? 🤔
To add the identifier being looked up to the HB error. Resolves #891.

## How was this change tested? 🤨
Unit and stage

![Screen Shot 2022-08-25 at 3 30 47 PM](https://user-images.githubusercontent.com/1619369/186752115-4f04ddcc-3851-4a1c-9857-5705606c53ee.png)


⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



