### PR TITLE
Adds indexing of folio hrid.

### DIFF
--- a/app/indexers/identity_metadata_indexer.rb
+++ b/app/indexers/identity_metadata_indexer.rb
@@ -13,12 +13,13 @@ class IdentityMetadataIndexer
 
     {
       'objectType_ssim' => [object_type],
-      'dor_id_tesim' => [source_id_value, barcode, catkey].compact,
+      'dor_id_tesim' => [source_id_value, barcode, catkey, folio_instance_hrid].compact,
       'identifier_ssim' => prefixed_identifiers,
       'identifier_tesim' => prefixed_identifiers,
       'barcode_id_ssim' => [barcode].compact,
       'catkey_id_ssim' => [catkey].compact,
-      'source_id_ssim' => [source_id].compact
+      'source_id_ssim' => [source_id].compact,
+      'folio_instance_hrid_ssim' => [folio_instance_hrid].compact
     }
   end
 
@@ -40,6 +41,10 @@ class IdentityMetadataIndexer
     @catkey ||= Array(cocina_object.identification.catalogLinks).find { |link| link.catalog == 'symphony' }&.catalogRecordId
   end
 
+  def folio_instance_hrid
+    @folio_instance_hrid ||= Array(cocina_object.identification.catalogLinks).find { |link| link.catalog == 'folio' }&.catalogRecordId
+  end
+
   def object_type
     case cocina_object
     when Cocina::Models::AdminPolicyWithMetadata
@@ -56,6 +61,7 @@ class IdentityMetadataIndexer
       identifiers << source_id if source_id
       identifiers << "barcode:#{barcode}" if barcode
       identifiers << "catkey:#{catkey}" if catkey
+      identifiers << "folio:#{folio_instance_hrid}" if folio_instance_hrid
     end
   end
 end

--- a/spec/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_indexer_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe IdentityMetadataIndexer do
               catalog: 'symphony',
               catalogRecordId: '129483625',
               refresh: true
+            },
+            {
+              catalog: 'folio',
+              catalogRecordId: 'a129483625',
+              refresh: true
             }
           ],
           barcode: '36105049267078'
@@ -31,11 +36,12 @@ RSpec.describe IdentityMetadataIndexer do
         expect(doc).to include(
           'barcode_id_ssim' => ['36105049267078'],
           'catkey_id_ssim' => ['129483625'],
-          'dor_id_tesim' => %w[STANFORD_342837261527 36105049267078 129483625],
+          'folio_instance_hrid_ssim' => ['a129483625'],
+          'dor_id_tesim' => %w[STANFORD_342837261527 36105049267078 129483625 a129483625],
           'identifier_ssim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
-                                'catkey:129483625'],
+                                'catkey:129483625', 'folio:a129483625'],
           'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
-                                 'catkey:129483625'],
+                                 'catkey:129483625', 'folio:a129483625'],
           'objectType_ssim' => ['item'],
           'source_id_ssim' => ['google:STANFORD_342837261527']
         )
@@ -73,6 +79,11 @@ RSpec.describe IdentityMetadataIndexer do
               catalog: 'symphony',
               catalogRecordId: '129483625',
               refresh: true
+            },
+            {
+              catalog: 'folio',
+              catalogRecordId: 'a129483625',
+              refresh: true
             }
           ]
         }
@@ -83,9 +94,10 @@ RSpec.describe IdentityMetadataIndexer do
         expect(doc).to include(
           'barcode_id_ssim' => [],
           'catkey_id_ssim' => ['129483625'],
-          'dor_id_tesim' => %w[STANFORD_342837261527 129483625],
-          'identifier_ssim' => ['google:STANFORD_342837261527', 'catkey:129483625'],
-          'identifier_tesim' => ['google:STANFORD_342837261527', 'catkey:129483625'],
+          'folio_instance_hrid_ssim' => ['a129483625'],
+          'dor_id_tesim' => %w[STANFORD_342837261527 129483625 a129483625],
+          'identifier_ssim' => ['google:STANFORD_342837261527', 'catkey:129483625', 'folio:a129483625'],
+          'identifier_tesim' => ['google:STANFORD_342837261527', 'catkey:129483625', 'folio:a129483625'],
           'objectType_ssim' => ['collection'],
           'source_id_ssim' => ['google:STANFORD_342837261527']
         )


### PR DESCRIPTION
closes #935

## Why was this change made? 🤔
Make HRIDs available in Argo.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, QA.

See https://argo-qa.stanford.edu/view/druid:bb408qn5061.json


