### PR TITLE
Index all present catalog link types into `metadata_source_ssim`

### DIFF
--- a/spec/indexers/composite_indexer_spec.rb
+++ b/spec/indexers/composite_indexer_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe CompositeIndexer do
         'nonhydrus_apo_title_ssim' => ['test admin policy'],
         'apo_title_ssim' => ['test admin policy'],
         'metadata_source_ssi' => 'DOR',
+        'metadata_source_ssim' => ['DOR'],
         'objectId_tesim' => ['druid:mx123ms3333', 'mx123ms3333'],
         'topic_ssim' => ['word'],
         'topic_tesim' => ['word']


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #946

This commit adds new indexing code to begin populating a new facet field allowing metadata sources to be multi-valued. This work is being done to support the migration from Symphony to Folio, during which objects will be expected to have one or two metadata sources. It is backwards compatible with the prior behavior---the commit is purely additive.


# How was this change tested? 🤨

CI
