### PR TITLE
Remove indexing of single-valued metadata source field

### DIFF
--- a/app/indexers/identifiable_indexer.rb
+++ b/app/indexers/identifiable_indexer.rb
@@ -18,22 +18,11 @@ class IdentifiableIndexer
     {}.tap do |solr_doc|
       add_apo_titles(solr_doc, cocina.administrative.hasAdminPolicy)
 
-      solr_doc['metadata_source_ssi'] = identity_metadata_source unless cocina.is_a? Cocina::Models::AdminPolicyWithMetadata
-      # NOTE: This will replace `metadata_source_ssi`
       solr_doc['metadata_source_ssim'] = identity_metadata_sources unless cocina.is_a? Cocina::Models::AdminPolicyWithMetadata
       # This used to be added to the index by https://github.com/sul-dlss/dor-services/commit/11b80d249d19326ef591411ffeb634900e75c2c3
       # and was called dc_identifier_druid_tesim
       # It is used to search based on druid.
       solr_doc['objectId_tesim'] = [cocina.externalIdentifier, cocina.externalIdentifier.delete_prefix('druid:')]
-    end
-  end
-
-  # @return [String] calculated value for Solr index
-  def identity_metadata_source
-    if cocina.identification&.catalogLinks&.any? { |link| link.catalog == 'symphony' }
-      'Symphony'
-    else
-      'DOR'
     end
   end
 

--- a/spec/indexers/composite_indexer_spec.rb
+++ b/spec/indexers/composite_indexer_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe CompositeIndexer do
         'sw_display_title_tesim' => 'Test item',
         'nonhydrus_apo_title_ssim' => ['test admin policy'],
         'apo_title_ssim' => ['test admin policy'],
-        'metadata_source_ssi' => 'DOR',
         'metadata_source_ssim' => ['DOR'],
         'objectId_tesim' => ['druid:mx123ms3333', 'mx123ms3333'],
         'topic_ssim' => ['word'],

--- a/spec/indexers/identifiable_indexer_spec.rb
+++ b/spec/indexers/identifiable_indexer_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe IdentifiableIndexer do
     described_class.reset_cache!
   end
 
-  describe '#identity_metadata_source' do
-    it 'indexes metadata source' do
-      expect(indexer.identity_metadata_source).to eq 'Symphony'
-    end
-  end
-
   describe '#identity_metadata_sources' do
     it 'indexes metadata sources' do
       expect(indexer.identity_metadata_sources).to eq %w[Folio Symphony]
@@ -73,12 +67,6 @@ RSpec.describe IdentifiableIndexer do
         expect(doc[Solrizer.solr_name('nonhydrus_apo_title', :symbol)].first).to eq 'collection title'
       end
 
-      it 'indexes metadata source' do
-        # rubocop:disable Style/StringHashKeys
-        expect(doc).to match a_hash_including('metadata_source_ssi' => 'Symphony')
-        # rubocop:enable Style/StringHashKeys
-      end
-
       it 'indexes metadata sources' do
         expect(doc).to match a_hash_including('metadata_source_ssim' => %w[Folio Symphony]) # rubocop:disable Style/StringHashKeys
       end
@@ -86,12 +74,6 @@ RSpec.describe IdentifiableIndexer do
 
     context 'without catalogLinks' do
       let(:identification) { { sourceId: 'sul:1234' } }
-
-      it 'indexes metadata source' do
-        # rubocop:disable Style/StringHashKeys
-        expect(doc).to match a_hash_including('metadata_source_ssi' => 'DOR')
-        # rubocop:enable Style/StringHashKeys
-      end
 
       it 'indexes metadata sources' do
         expect(doc).to match a_hash_including('metadata_source_ssim' => ['DOR']) # rubocop:disable Style/StringHashKeys
@@ -110,12 +92,6 @@ RSpec.describe IdentifiableIndexer do
         }
       end
 
-      it 'indexes metadata source' do
-        # rubocop:disable Style/StringHashKeys
-        expect(doc).to match a_hash_including('metadata_source_ssi' => 'DOR')
-        # rubocop:enable Style/StringHashKeys
-      end
-
       it 'indexes metadata sources' do
         expect(doc).to match a_hash_including('metadata_source_ssim' => ['DOR']) # rubocop:disable Style/StringHashKeys
       end
@@ -123,12 +99,6 @@ RSpec.describe IdentifiableIndexer do
 
     context 'with no identification sub-schema' do
       let(:cocina_item) { build(:dro, id: druid, admin_policy_id: apo_id) }
-
-      it 'indexes metadata source' do
-        # rubocop:disable Style/StringHashKeys
-        expect(doc).to match a_hash_including('metadata_source_ssi' => 'DOR')
-        # rubocop:enable Style/StringHashKeys
-      end
 
       it 'indexes metadata sources' do
         expect(doc).to match a_hash_including('metadata_source_ssim' => ['DOR']) # rubocop:disable Style/StringHashKeys


### PR DESCRIPTION
~~This is **ON HOLD** until reindexing has been done in all environments.~~

## Why was this change made? 🤔

Fixes #947

This commit removes metadata source indexing that is no longer needed after the Folio migration is complete.


## How was this change tested? 🤨

CI
