### PR TITLE
index dois and orcidids

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -55,8 +55,7 @@ class DescriptiveMetadataIndexer
   end
 
   def orcids
-    cited_contributors = cocina.description.contributor.select { |contributor| cited?(contributor) }
-    cited_contributors.filter_map { |contributor| orcidid(contributor) }
+    OrcidBuilder.build(Array(cocina.description.contributor))
   end
 
   def title
@@ -206,21 +205,6 @@ class DescriptiveMetadataIndexer
 
   def flat_value(value)
     value.parallelValue.presence || value.groupedValue.presence || value.structuredValue.presence || Array(value)
-  end
-
-  # @param [Cocina::Models::Contributor] contributor to check
-  # @return [Boolean] true unless the contributor has a citation status of false
-  def cited?(contributor)
-    contributor.note.none? { |note| note.type == 'citation status' && note.value == 'false' }
-  end
-
-  # @param [Cocina::Models::Contributor] contributor to check
-  # @return [String, nil] orcid id including host if present
-  def orcidid(contributor)
-    identifier = contributor.identifier.find { |id| id.type == 'ORCID' }
-    return unless identifier
-
-    URI.join(identifier.source.uri, identifier.value).to_s
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/indexers/identity_metadata_indexer.rb
+++ b/app/indexers/identity_metadata_indexer.rb
@@ -19,7 +19,8 @@ class IdentityMetadataIndexer
       'barcode_id_ssim' => [barcode].compact,
       'catkey_id_ssim' => [catkey].compact,
       'source_id_ssim' => [source_id].compact,
-      'folio_instance_hrid_ssim' => [folio_instance_hrid].compact
+      'folio_instance_hrid_ssim' => [folio_instance_hrid].compact,
+      'doi_ssim' => [doi].compact
     }
   end
 
@@ -44,6 +45,10 @@ class IdentityMetadataIndexer
   def previous_catkeys
     @previous_catkeys ||=
       Array(cocina_object.identification.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == 'previous symphony' }
+  end
+
+  def doi
+    @doi ||= object_type == 'item' ? cocina_object.identification.doi : nil
   end
 
   def folio_instance_hrid

--- a/app/services/orcid_builder.rb
+++ b/app/services/orcid_builder.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class OrcidBuilder
+  # @param [Array<Cocina::Models::Contributor>] contributors
+  # @return [String] the list of contributor ORCIDs to index into solr
+  def self.build(contributors)
+    new(contributors).build
+  end
+
+  def initialize(contributors)
+    @contributors = Array(contributors)
+  end
+
+  def build
+    cited_contributors.filter_map { |contributor| orcidid(contributor) }
+  end
+
+  private
+
+  attr_reader :contributors
+
+  # @param [Cocina::Models::Contributor] array of contributors
+  # @return [Array<String>] array of contributors who are listed as cited
+  # Note that non-cited contributors are excluded.
+  def cited_contributors
+    contributors.select { |contributor| cited?(contributor) }
+  end
+
+  # @param [Cocina::Models::Contributor] contributor to check
+  # @return [Boolean] true unless the contributor has a citation status of false
+  def cited?(contributor)
+    contributor.note.none? { |note| note.type == 'citation status' && note.value == 'false' }
+  end
+
+  # @param [Cocina::Models::Contributor] contributor to check
+  # @return [String, nil] orcid id including host if present
+  def orcidid(contributor)
+    identifier = contributor.identifier.find { |id| id.type == 'ORCID' }
+    return unless identifier
+
+    URI.join(identifier.source.uri, identifier.value).to_s
+  end
+end

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -57,7 +57,16 @@ RSpec.describe DescriptiveMetadataIndexer do
             source: {
               code: 'marcrelator'
             }
-          }]
+          }],
+          identifier: [
+            {
+              value: '0000-1111-2222-3333',
+              type: 'ORCID',
+              source: {
+                uri: 'https://orcid.org'
+              }
+            }
+          ]
         },
         {
           name: [
@@ -336,7 +345,8 @@ RSpec.describe DescriptiveMetadataIndexer do
         'originInfo_publisher_tesim' => 'Doubleday, Page',
         'originInfo_place_placeTerm_tesim' => 'Garden City, N. Y',
         'topic_ssim' => %w[cats Economics],
-        'topic_tesim' => %w[cats Economics]
+        'topic_tesim' => %w[cats Economics],
+        'contributor_orcids_ssim' => ['https://orcid.org/0000-1111-2222-3333']
       )
     end
     # rubocop:enable Style/StringHashKeys

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -84,6 +84,28 @@ RSpec.describe DescriptiveMetadataIndexer do
             }
           ],
           type: 'person'
+        },
+        {
+          name: [
+            {
+              structuredValue: [
+                {
+                  value: 'George, Bush',
+                  type: 'name'
+                }
+              ]
+            }
+          ],
+          type: 'person',
+          identifier: [
+            {
+              value: '1111-2222-3333-4444',
+              type: 'ORCID',
+              source: {
+                uri: 'https://orcid.org'
+              }
+            }
+          ]
         }
       ],
       event: [{
@@ -346,7 +368,7 @@ RSpec.describe DescriptiveMetadataIndexer do
         'originInfo_place_placeTerm_tesim' => 'Garden City, N. Y',
         'topic_ssim' => %w[cats Economics],
         'topic_tesim' => %w[cats Economics],
-        'contributor_orcids_ssim' => ['https://orcid.org/0000-1111-2222-3333']
+        'contributor_orcids_ssim' => ['https://orcid.org/0000-1111-2222-3333', 'https://orcid.org/1111-2222-3333-4444']
       )
     end
     # rubocop:enable Style/StringHashKeys

--- a/spec/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_indexer_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe IdentityMetadataIndexer do
               refresh: true
             }
           ],
-          barcode: '36105049267078'
+          barcode: '36105049267078',
+          doi: '10.25740/yr775yn6440'
         }
       end
 
@@ -58,7 +59,8 @@ RSpec.describe IdentityMetadataIndexer do
           'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                                  'catkey:129483625', 'folio:a129483625'],
           'objectType_ssim' => ['item'],
-          'source_id_ssim' => ['google:STANFORD_342837261527']
+          'source_id_ssim' => ['google:STANFORD_342837261527'],
+          'doi_ssim' => ['10.25740/yr775yn6440']
         )
       end
       # rubocop:enable Style/StringHashKeys


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/argo/issues/4096

This will index DOIs (for items) and ORCIDIDs (for contributors) into solr.  

There will then be a separate Argo PR to add the appropriate facet (e.g. 'Identifiers', which then has multiple values, searching for any objects where the DOI/ORCID fields are *not* null).

~~HOLD pending test in QA or stage~~

## How was this change tested? 🤨

New tests


