### PR TITLE
deal with a different orcid format

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ $ cap ENV rolling_indexer:restart
 Or if you're on a server that has the `rolling_indexer` capistrano role, use systemd commands:
 
 ```shell
-$ sudo systemctl status rolling_index
-$ sudo systemctl start rolling_index
-$ sudo systemctl stop rolling_index
-$ sudo systemctl restart rolling_index
+$ sudo systemctl status rolling-index
+$ sudo systemctl start rolling-index
+$ sudo systemctl stop rolling-index
+$ sudo systemctl restart rolling-index
 ```
 
 **NOTE 1**: The rolling indexer is automatically restarted during deployments.

--- a/app/services/orcid_builder.rb
+++ b/app/services/orcid_builder.rb
@@ -38,6 +38,9 @@ class OrcidBuilder
     identifier = contributor.identifier.find { |id| id.type == 'ORCID' }
     return unless identifier
 
+    # some records have the full ORCID URI in the data, just return it if so, e.g. druid:gf852zt8324
+    return identifier.uri if identifier.uri
+
     URI.join(identifier.source.uri, identifier.value).to_s
   end
 end

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -99,10 +99,10 @@ RSpec.describe DescriptiveMetadataIndexer do
           type: 'person',
           identifier: [
             {
-              value: '1111-2222-3333-4444',
+              uri: 'https://orcid.org/1111-2222-3333-4444',
               type: 'ORCID',
               source: {
-                uri: 'https://orcid.org'
+                code: 'orcid'
               }
             }
           ]


### PR DESCRIPTION
## Why was this change made? 🤔

This HB alert was triggered when trying to index records with a different ORCID format in the descriptive cocina than we were expecting.  This allows us to deal with it.  

see https://app.honeybadger.io/projects/49898/faults/99952126 and https://argo-prod-02.stanford.edu/view/druid:gf852zt8324 for the example record

## How was this change tested? 🤨

Updated spec to include the alternate format.



