### PR TITLE
Update indexing for topic_ssim to use Stanford::Mods::SearchworksSubj…

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -29,7 +29,7 @@ class DescriptiveMetadataIndexer
       'originInfo_date_created_tesim' => creation_date,
       'originInfo_publisher_tesim' => publisher_name,
       'originInfo_place_placeTerm_tesim' => event_place,
-      'topic_ssim' => nonstemmable_topics,
+      'topic_ssim' => stanford_mods_record.topic_facet.uniq,
       'topic_tesim' => stemmable_topics,
       'metadata_format_ssim' => 'mods' # NOTE: seriously? for cocina????
     }.select { |_k, v| v.present? }
@@ -166,13 +166,6 @@ class DescriptiveMetadataIndexer
 
   def stemmable_topics
     TopicBuilder.build(Array(cocina.description.subject), filter: 'topic')
-  end
-
-  def nonstemmable_topics
-    (
-      TopicBuilder.build(Array(cocina.description.subject), filter: 'topic', remove_trailing_punctuation: true) +
-      TopicBuilder.build(Array(cocina.description.subject), filter: 'name')
-    ).compact
   end
 
   def publication_event

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe DescriptiveMetadataIndexer do
         # 'originInfo_date_created_tesim' => '', # not populated by the example; see indexer_spec instead
         'originInfo_publisher_tesim' => 'Doubleday, Page',
         'originInfo_place_placeTerm_tesim' => 'Garden City, N. Y',
-        'topic_ssim' => %w[cats Economics],
+        'topic_ssim' => %w[Economics cats],
         'topic_tesim' => %w[cats Economics],
         'contributor_orcids_ssim' => ['https://orcid.org/0000-1111-2222-3333', 'https://orcid.org/1111-2222-3333-4444', 'https://orcid.org/0000-0001-5321-289X']
       )

--- a/spec/indexers/descriptive_metadata_indexer_subject_topic_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_subject_topic_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects name from subject for topic_ssim' do
-        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy L., 1983-1957', 'Sayers, Dorothy L.'])
+        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy L.'])
         expect(doc).not_to include('topic_tesim')
       end
     end
@@ -426,7 +426,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'constructs name subject for topic_ssim' do
-        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy L.'])
+        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy, L.'])
         expect(doc).not_to include('topic_tesim')
       end
     end
@@ -512,7 +512,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'constructs names from subjects in parallelValue for topic_ssim' do
-        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy L.', 'Сэйерс, Дороти Л.'])
+        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy, L.', 'Сэйерс, Дороти, Л.'])
         expect(doc).not_to include('topic_tesim')
       end
     end
@@ -556,7 +556,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'constructs name subject for topic_ssim and selects topic subject' do
-        expect(doc['topic_ssim']).to contain_exactly('Sayers, Dorothy L.', 'Homes and haunts')
+        expect(doc['topic_ssim']).to contain_exactly('Sayers, Dorothy, L.', 'Homes and haunts')
         expect(doc).to include('topic_tesim' => ['Homes and haunts'])
       end
     end


### PR DESCRIPTION
…ects.topic_facet

## Why was this change made? 🤔

Part of #992 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



