### PR TITLE
Update sw_subject_geographic_ssim to use Stanford::Mods::SearchworksS…

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -24,7 +24,7 @@ class DescriptiveMetadataIndexer
       'contributor_orcids_ssim' => orcids,
       'sw_display_title_tesim' => title,
       'sw_subject_temporal_ssim' => subject_temporal,
-      'sw_subject_geographic_ssim' => subject_geographic,
+      'sw_subject_geographic_ssim' => stanford_mods_record.geographic_facet.uniq,
       'sw_pub_date_facet_ssi' => pub_year,
       'originInfo_date_created_tesim' => creation_date,
       'originInfo_publisher_tesim' => publisher_name,

--- a/spec/indexers/descriptive_metadata_indexer_subject_geographic_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_subject_geographic_spec.rb
@@ -233,8 +233,8 @@ RSpec.describe DescriptiveMetadataIndexer do
         }
       end
 
-      it 'maps the code to text' do
-        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
+      it 'does not map the code to text' do
+        expect(doc).not_to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
       end
     end
 
@@ -318,8 +318,8 @@ RSpec.describe DescriptiveMetadataIndexer do
         }
       end
 
-      it 'maps the code to text' do
-        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
+      it 'does not map the code to text' do
+        expect(doc).not_to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
       end
     end
 
@@ -416,8 +416,8 @@ RSpec.describe DescriptiveMetadataIndexer do
         }
       end
 
-      it 'includes term once' do
-        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
+      it 'does not include the term' do
+        expect(doc).not_to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
       end
     end
 
@@ -442,8 +442,8 @@ RSpec.describe DescriptiveMetadataIndexer do
         }
       end
 
-      it 'includes both terms' do
-        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia', 'Russia (Federation)'])
+      it 'does not include both terms' do
+        expect(doc).not_to include('sw_subject_geographic_ssim' => ['Russia', 'Russia (Federation)'])
       end
     end
 
@@ -656,31 +656,6 @@ RSpec.describe DescriptiveMetadataIndexer do
 
       it 'drops the punctuation before deduping' do
         expect(doc).to include('sw_subject_geographic_ssim' => ['Europe'])
-      end
-    end
-
-    context 'when terminal punctuation should be dropped from code' do
-      let(:description) do
-        {
-          title: [
-            {
-              value: 'title'
-            }
-          ],
-          subject: [
-            {
-              code: 'e-ru;',
-              type: 'place',
-              source: {
-                code: 'marcgac'
-              }
-            }
-          ]
-        }
-      end
-
-      it 'drops the punctuation' do
-        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)'])
       end
     end
   end


### PR DESCRIPTION
…ubjects.geographic_facet

## Why was this change made? 🤔

Part of #992 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



