### PR TITLE
Update sw_language_ssim to use Stanford::Mods::Searchworks.sw_languag…

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -16,7 +16,7 @@ class DescriptiveMetadataIndexer
   # @return [Hash] the partial solr document for descriptive metadata
   def to_solr
     {
-      'sw_language_ssim' => language,
+      'sw_language_ssim' => stanford_mods_record.sw_language_facet,
       'mods_typeOfResource_ssim' => resource_type,
       'sw_format_ssim' => sw_format,
       'sw_genre_ssim' => stanford_mods_record.sw_genre,
@@ -37,10 +37,6 @@ class DescriptiveMetadataIndexer
   # rubocop:enable Metrics/MethodLength
 
   private
-
-  def language
-    LanguageBuilder.build(Array(cocina.description.language))
-  end
 
   def subject_temporal
     TemporalBuilder.build(subjects)

--- a/spec/indexers/descriptive_metadata_indexer_language_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_language_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
-        expect(doc).to include('sw_language_ssim' => ['English, Old (ca.450-1100)'])
+        expect(doc).to include('sw_language_ssim' => ['English, Old (ca. 450-1100)'])
       end
     end
 
@@ -171,7 +171,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           ],
           language: [
             {
-              value: 'English, Old (ca.450-1100)',
+              value: 'English, Old (ca. 450-1100)',
               code: 'enk',
               source: {
                 code: 'iso639-2b'
@@ -182,7 +182,7 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'includes text value' do
-        expect(doc).to include('sw_language_ssim' => ['English, Old (ca.450-1100)'])
+        expect(doc).to include('sw_language_ssim' => ['English, Old (ca. 450-1100)'])
       end
     end
 
@@ -255,8 +255,8 @@ RSpec.describe DescriptiveMetadataIndexer do
         }
       end
 
-      it 'does not include a value' do
-        expect(doc).not_to include('sw_language_ssim')
+      it 'defaults to the searchworks language vocabulary' do
+        expect(doc).to include('sw_language_ssim' => ['English'])
       end
     end
 


### PR DESCRIPTION
…e_facet

## Why was this change made? 🤔

Part of #992 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



