### PR TITLE
Exploded project tag indexing etc

### DIFF
--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -27,7 +27,12 @@ class AdministrativeTagIndexer
       next if SPECIAL_TAG_TYPES_TO_INDEX.exclude?(tag_prefix) || rest.nil?
 
       prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
+
       (solr_doc["#{prefix}_tag_ssim"] ||= []) << rest.strip
+      if prefix == 'project'
+        solr_doc['exploded_project_tag_ssim'] ||= []
+        solr_doc['exploded_project_tag_ssim'] += exploded_tags_from(rest.strip)
+      end
     end
     solr_doc
   end

--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -5,7 +5,7 @@
 #       https://github.com/sul-dlss/dor-services/blob/v9.0.0/lib/dor/datastreams/identity_metadata_ds.rb#L196-L218
 class AdministrativeTagIndexer
   TAG_PART_DELIMITER = ' : '
-  TAGS_TO_INDEX = ['Project', 'Registered By'].freeze
+  SPECIAL_TAG_TYPES_TO_INDEX = ['Project', 'Registered By'].freeze
 
   attr_reader :id
 
@@ -24,7 +24,7 @@ class AdministrativeTagIndexer
       solr_doc['exploded_tag_ssim'] += exploded_tags_from(tag)
 
       tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
-      next if TAGS_TO_INDEX.exclude?(tag_prefix) || rest.nil?
+      next if SPECIAL_TAG_TYPES_TO_INDEX.exclude?(tag_prefix) || rest.nil?
 
       prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
       (solr_doc["#{prefix}_tag_ssim"] ||= []) << rest.strip

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe AdministrativeTagIndexer do
     it 'indexes exploded tags' do
       expect(document['exploded_tag_ssim']).to contain_exactly('Google Books', 'Google Books : Phase 1', 'Google Books', 'Google Books : Scan source STANFORD', 'Project',
                                                                'Project : Beautiful Books', 'Registered By', 'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books', 'DPG : Beautiful Books : Octavo', 'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
+      expect(document['exploded_project_tag_ssim']).to contain_exactly('Beautiful Books')
+      expect(document).not_to have_key('exploded_registered_by_tag_ssim')
     end
 
     it 'indexes prefixed tags' do

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe AdministrativeTagIndexer do
         'Google Books : Phase 1',
         'Google Books : Scan source STANFORD',
         'Project : Beautiful Books',
+        'Project : Rare Books : Very Old Books',
         'Registered By : blalbrit',
         'DPG : Beautiful Books : Octavo : newpri',
         'Remediated By : 4.15.4'
@@ -27,15 +28,17 @@ RSpec.describe AdministrativeTagIndexer do
 
     it 'indexes exploded tags' do
       expect(document['exploded_tag_ssim']).to contain_exactly('Google Books', 'Google Books : Phase 1', 'Google Books', 'Google Books : Scan source STANFORD', 'Project',
-                                                               'Project : Beautiful Books', 'Registered By', 'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books', 'DPG : Beautiful Books : Octavo', 'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
-      expect(document['exploded_project_tag_ssim']).to contain_exactly('Beautiful Books')
+                                                               'Project : Beautiful Books', 'Project', 'Project : Rare Books', 'Project : Rare Books : Very Old Books', 'Registered By',
+                                                               'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books', 'DPG : Beautiful Books : Octavo',
+                                                               'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
+      expect(document['exploded_project_tag_ssim']).to contain_exactly('Beautiful Books', 'Rare Books', 'Rare Books : Very Old Books')
       expect(document).not_to have_key('exploded_registered_by_tag_ssim')
     end
 
     it 'indexes prefixed tags' do
       # rubocop:disable Style/StringHashKeys
       expect(document).to include(
-        'project_tag_ssim' => ['Beautiful Books'],
+        'project_tag_ssim' => ['Beautiful Books', 'Rare Books : Very Old Books'],
         'registered_by_tag_ssim' => ['blalbrit']
       )
       # rubocop:enable Style/StringHashKeys


### PR DESCRIPTION
## Why was this change made? 🤔

fixes #1004

deviations from the suggestions in the ticket
* ticket suggests adding a private helper method `project_tag?`, but the tag splitting that's already there makes this feel a little unnecessary.  even as groundwork for #1006, which #1004 blocks, this feels a little unnecessary given what's already there
* ticket suggests writing "project tags to a new Solr field, `project_tag_ssim`"... but afaict, we are already indexing project tags that way?  i see it in the DIA solr doc building code and unit tests, and in the Solr admin schema view, and in use in the argo code.  so i just left that as-is.

per the ticket, i only indexed `exploded_project_tag`, but it'd be easy to do a similar sort of indexing for the other special tag, `Registered By`/`registered_by`.

## How was this change tested? 🤨

- [x] unit tests/CI
- [x] deploy to stage or QA
- [x] examined solr doc for a QA object with project tags, and one without, confirmed that project and exploded project tag fields looked fine on former, and that they weren't present on latter

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



