### PR TITLE
index exploded tags that aren't project tags to their own field

### DIFF
--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -18,7 +18,7 @@ class AdministrativeTagIndexer
   def to_solr
     Rails.logger.debug { "In #{self.class}" }
 
-    solr_doc = { 'tag_ssim' => [], 'exploded_tag_ssim' => [] }
+    solr_doc = { 'tag_ssim' => [], 'exploded_tag_ssim' => [], 'exploded_nonproject_tag_ssim' => [] }
     administrative_tags.each do |tag|
       tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
       prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
@@ -26,9 +26,12 @@ class AdministrativeTagIndexer
       solr_doc['tag_ssim'] << tag
       solr_doc['exploded_tag_ssim'] += exploded_tags_from(tag)
 
+      solr_doc['exploded_nonproject_tag_ssim'] += exploded_tags_from(tag) unless prefix == 'project'
+
       next if SPECIAL_TAG_TYPES_TO_INDEX.exclude?(tag_prefix) || rest.nil?
 
       (solr_doc["#{prefix}_tag_ssim"] ||= []) << rest.strip
+
       if prefix == 'project'
         solr_doc['exploded_project_tag_ssim'] ||= []
         solr_doc['exploded_project_tag_ssim'] += exploded_tags_from(rest.strip)

--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -20,13 +20,13 @@ class AdministrativeTagIndexer
 
     solr_doc = { 'tag_ssim' => [], 'exploded_tag_ssim' => [] }
     administrative_tags.each do |tag|
+      tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
+      prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
+
       solr_doc['tag_ssim'] << tag
       solr_doc['exploded_tag_ssim'] += exploded_tags_from(tag)
 
-      tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
       next if SPECIAL_TAG_TYPES_TO_INDEX.exclude?(tag_prefix) || rest.nil?
-
-      prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
 
       (solr_doc["#{prefix}_tag_ssim"] ||= []) << rest.strip
       if prefix == 'project'

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe AdministrativeTagIndexer do
                                                                'Project : Beautiful Books', 'Project', 'Project : Rare Books', 'Project : Rare Books : Very Old Books', 'Registered By',
                                                                'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books', 'DPG : Beautiful Books : Octavo',
                                                                'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
+      expect(document['exploded_nonproject_tag_ssim']).to contain_exactly('Google Books', 'Google Books : Phase 1', 'Google Books', 'Google Books : Scan source STANFORD',
+                                                                          'Registered By',
+                                                                          'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books', 'DPG : Beautiful Books : Octavo',
+                                                                          'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
       expect(document['exploded_project_tag_ssim']).to contain_exactly('Beautiful Books', 'Rare Books', 'Rare Books : Very Old Books')
       expect(document).not_to have_key('exploded_registered_by_tag_ssim')
     end


### PR DESCRIPTION
## Why was this change made? 🤔

fixes #1006, which says:
> Write code to index (exploded) non-project tags into a NEW Solr field for all that is in the current exploded tags field (exploded_tags_ssim) except project tags.

## How was this change tested? 🤨

- [x] unit tests
- [ ] deploy to stage or QA for manual and/or integration testing?

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



