### PR TITLE
Stop indexing obj_label.

### DIFF
--- a/app/indexers/data_indexer.rb
+++ b/app/indexers/data_indexer.rb
@@ -13,7 +13,6 @@ class DataIndexer
       Rails.logger.debug { "In #{self.class}" }
       solr_doc[:id] = cocina.externalIdentifier
       solr_doc['current_version_isi'] = cocina.version # Argo Facet field "Version"
-      solr_doc['obj_label_tesim'] = cocina.label
 
       solr_doc['modified_latest_dttsi'] = modified_latest
       solr_doc['created_at_dttsi'] = created_at

--- a/spec/indexers/data_indexer_spec.rb
+++ b/spec/indexers/data_indexer_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe DataIndexer do
 
       it 'makes a solr doc' do
         expect(doc).to eq(
-          'obj_label_tesim' => 'item label',
           'current_version_isi' => 4,
           'milestones_ssim' => %w[foo bar],
           'has_constituents_ssim' => nil,
@@ -54,7 +53,6 @@ RSpec.describe DataIndexer do
 
       it 'makes a solr doc' do
         expect(doc).to eq(
-          'obj_label_tesim' => 'item label',
           'current_version_isi' => 4,
           'milestones_ssim' => %w[foo bar],
           'is_governed_by_ssim' => 'info:fedora/druid:vv888vv8888',
@@ -74,7 +72,6 @@ RSpec.describe DataIndexer do
 
       it 'makes a solr doc' do
         expect(doc).to eq(
-          'obj_label_tesim' => 'item label',
           'current_version_isi' => 4,
           'milestones_ssim' => %w[foo bar],
           'has_constituents_ssim' => ['druid:bb777bb7777', 'druid:dd666dd6666'],


### PR DESCRIPTION
closes #1033

## Why was this change made? 🤔
It's not used.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

