### PR TITLE
descriptive text catch all searching field changes

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -32,7 +32,9 @@ class DescriptiveMetadataIndexer
       'topic_ssim' => stanford_mods_record.topic_facet.uniq,
       'topic_tesim' => stemmable_topics,
       'metadata_format_ssim' => 'mods', # NOTE: seriously? for cocina????
-      'all_text_timv' => all_text
+      'descriptive_tiv' => all_search_text, # ICU tokenized, ICU folded
+      'descriptive_text_nostem_i' => all_search_text, # whitespace tokenized, ICU folded, word delimited
+      'descriptive_teiv' => all_search_text # ICU tokenized, ICU folded, minimal stemming
     }.select { |_k, v| v.present? }
   end
   # rubocop:enable Metrics/MethodLength
@@ -185,8 +187,8 @@ class DescriptiveMetadataIndexer
     value.parallelValue.presence || value.groupedValue.presence || value.structuredValue.presence || Array(value)
   end
 
-  def all_text
-    AllTextBuilder.build(cocina.description)
+  def all_search_text
+    @all_search_text ||= AllSearchTextBuilder.build(cocina.description)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/all_search_text_builder.rb
+++ b/app/services/all_search_text_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Extracts useful text from Cocina Description
-class AllTextBuilder
+# Extracts useful text for searching from Cocina Description
+class AllSearchTextBuilder
   def self.build(cocina_description)
     new(cocina_description).build
   end
@@ -13,15 +13,15 @@ class AllTextBuilder
   def build
     @text = []
     recurse(cocina_description)
-    text.uniq
+    text.join(' ')
   end
 
   private
 
   attr_reader :cocina_description, :text
 
+  # this originally had displayLabel, but Arcadia recommends against it
   TEXT_KEYS = %i[
-    displayLabel
     value
   ].freeze
 

--- a/spec/indexers/composite_indexer_spec.rb
+++ b/spec/indexers/composite_indexer_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe CompositeIndexer do
       # rubocop:disable Style/StringHashKeys
       expect(doc).to eq(
         'metadata_format_ssim' => 'mods',
-        'all_text_timv' => ['Test item', 'word'],
+        'descriptive_tiv' => 'Test item word',
+        'descriptive_teiv' => 'Test item word',
+        'descriptive_text_nostem_i' => 'Test item word',
         'sw_display_title_tesim' => 'Test item',
         'nonhydrus_apo_title_ssim' => ['test admin policy'],
         'apo_title_ssim' => ['test admin policy'],

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -378,34 +378,17 @@ RSpec.describe DescriptiveMetadataIndexer do
   describe '#to_solr' do
     # rubocop:disable Style/StringHashKeys
     it 'populates expected fields' do
+      all_search_text = 'The complete works of Henry George 4 George, Henry 1839-1897 George, Henry 1862-1916 George, Bush ' \
+                        'Wiles, Simon Doubleday, Page [Library ed.] monographic Garden City, N. Y text electronic ' \
+                        'preservation reformatted digital On cover: Complete works of Henry George. Fels fund. ' \
+                        'Library edition. I. Progress and poverty.--II. Social problems.--III. The land question. ' \
+                        'Property in land. blah blah print 10 v. fronts (v. 1-9) ports. 21 cm. Economics 1800-1900 ' \
+                        'Economics Europe cats'
       expect(doc).to eq(
         'metadata_format_ssim' => 'mods',
-        'all_text_timv' => [
-          'The',
-          'complete works of Henry George',
-          '4',
-          'George, Henry',
-          '1839-1897',
-          '1862-1916',
-          'George, Bush',
-          'Wiles, Simon',
-          'Doubleday, Page',
-          '[Library ed.]',
-          'monographic',
-          'Garden City, N. Y',
-          'text',
-          'electronic',
-          'preservation',
-          'reformatted digital',
-          'On cover: Complete works of Henry George. Fels fund. Library edition.',
-          'I. Progress and poverty.--II. Social problems.--III. The land question. Property in land. blah blah',
-          'print',
-          '10 v. fronts (v. 1-9) ports. 21 cm.',
-          'Economics',
-          '1800-1900',
-          'Europe',
-          'cats'
-        ],
+        'descriptive_tiv' => all_search_text,
+        'descriptive_teiv' => all_search_text,
+        'descriptive_text_nostem_i' => all_search_text,
         'sw_language_ssim' => ['English'],
         'sw_format_ssim' => ['Book'],
         'mods_typeOfResource_ssim' => ['text'],
@@ -473,16 +456,17 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'populates expected fields' do
+        all_search_text = 'Toldot ha-Yehudim be-artsot ha-Islam ha-ʻet ' \
+                          'ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19 ' \
+                          'תולדות היהודים בארצות האיסלאם ' \
+                          'העת החדשה עד אמצע המאה ה־19 History of the ' \
+                          'Jews in the Islamic countries'
         # rubocop:disable Style/StringHashKeys
         expect(doc).to eq(
           'metadata_format_ssim' => 'mods',
-          'all_text_timv' => [
-            'Toldot ha-Yehudim be-artsot ha-Islam',
-            'ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19',
-            'תולדות היהודים בארצות האיסלאם',
-            'העת החדשה עד אמצע המאה ה־19',
-            'History of the Jews in the Islamic countries'
-          ],
+          'descriptive_tiv' => all_search_text,
+          'descriptive_teiv' => all_search_text,
+          'descriptive_text_nostem_i' => all_search_text,
           'sw_display_title_tesim' => 'Toldot ha-Yehudim be-artsot ha-Islam : ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19'
         )
         # rubocop:enable Style/StringHashKeys


### PR DESCRIPTION
## Why was this change made? 🤔

- Arcadia suggested NOT indexing displayLabel values
- it should be a string, not separate values, so phrase searching works for values broken into bits (titles, names, topics ...)
- it should be indexed into 3 fields with different text analysis algorithms (stemming, tokenization ...)

## How was this change tested? 🤨

specs


