### PR TITLE
Parallelize the slowest part of the rolling indexer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'iso-639', '~> 0.3.5'
 gem 'language_list'
 gem 'marc-vocab', '~> 0.3.0'
 gem 'okcomputer' # for monitoring
+gem 'parallel'
 gem 'puma', '~> 5.3' # app server
 gem 'rack-timeout', '~> 0.5.1'
 gem 'rails', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,6 +460,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   marc-vocab (~> 0.3.0)
   okcomputer
+  parallel
   parse_date
   puma (~> 5.3)
   rack-timeout (~> 0.5.1)

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -2,6 +2,7 @@
 
 require_relative '../config/environment'
 require 'daemons'
+require 'parallel'
 
 QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id', rows: '500' }
 
@@ -9,20 +10,26 @@ Daemons.run_proc('rolling index') do
   loop do
     solr_conn = RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
     response = solr_conn.get 'select', params: QUERY
-    response['response']['docs'].each do |doc|
+    solr_docs = Parallel.map(response['response']['docs'], in_processes: 8) do |doc|
       identifier = doc['id'].scrub('')
       # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
       Honeybadger.notify("Identifier isn't valid utf-8", { identifier: identifier, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
       begin
+        # This returns a Solr doc instance
         Indexer.load_and_index(solr: solr_conn, identifier: identifier)
       rescue Dor::Services::Client::NotFoundResponse
         Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
         # Clean up cruft in QA and stage
         Indexer.delete(solr: solr_conn, identifier: identifier) if ['stage', 'qa'].include?(ENV['HONEYBADGER_ENV'])
+        # Return `nil`, which is compacted, so the Solr add isn't grumpy
+        nil
       rescue Dor::Services::Client::UnexpectedResponse
         Honeybadger.notify('Unexpected response from Dor Services App.', { druid: identifier })
+        # Return `nil`, which is compacted, so the Solr add isn't grumpy
+        nil
       end
-    end
+    end.compact
+    solr_conn.add(solr_docs, add_attributes: { commitWithin: 1000 })
     sleep(5) # This was just a wild guess.  We can turn this up/down as necessary.
   end
 end

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -16,7 +16,7 @@ Daemons.run_proc('rolling index') do
       Honeybadger.notify("Identifier isn't valid utf-8", { identifier: identifier, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
       begin
         # This returns a Solr doc instance
-        Indexer.load_and_index(solr: solr_conn, identifier: identifier)
+        Indexer.load_and_build(identifier: identifier)
       rescue Dor::Services::Client::NotFoundResponse
         Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
         # Clean up cruft in QA and stage


### PR DESCRIPTION
# Why was this change made?

The rolling indexer is slower than we think it should be. We currently estimate that a complete reindex of SDR takes roughly ~11 days to finish. Naomi and I spent some time benchmarking the indexer, and noticed two ways we could speed this up:

1. Reduce the number of times we add docs to Solr from 500 to 1, as `RSolr::Client#add` can take a batch of docs in an array (shaves ~10s off the run);
2. Parallelize the `Dor::Services::Client#find` and the `Indexer.load_and_index` calls, which is where the indexer was spending most of its time

As a result, a typical run in prod takes ~20 seconds instead of ~145 seconds.  This is a seven fold increase (based on our sample size of 1 run).   See below for benchmarking results.

We also tested varying the Solr `commitWithin` value and found that higher values did not yield a faster runtime, which pointed to the source of sluggishness being elsewhere (namely the DSC and Indexer calls mentioned above):

```
                             user     system      total        real
index 500 (1s commit)   58.971828   2.422009  61.393837 (144.080748)
index 500 (10s commit)  59.640639   2.644295  62.284934 (143.016791)
index 500 (100s commit) 59.226527   2.276780  61.503307 (144.232593)
```

## Before

```
                             user     system      total        real
index 500 (1s commit):  61.467601   2.203758  63.671359 (142.879938)
```

## After parallelization

```
                                   user     system      total        real
index 500 as array (parallel)  1.045042   0.097685  60.504973 ( 20.565835)
```

## After adding `Indexer.load_and_build`

```
                                     user     system      total        real
only add once (for real)         1.084629   0.090197  60.799066 ( 18.072022)
```

## How Slow Has It Been?

We currently have around 7M objects in the index, and we're indexing 500 at a time,  so this will take 7M/500 = 14,000 iterations.  If each iteration takes 1 minute to run, then it's 14,000 minutes = 233 hours = 10 days PLUS 5 seconds wait time for each iteration, which adds another 19.4 hours so ... basically 11 days.  Except in observation, it seems it takes longer than 2 weeks.  See https://github.com/sul-dlss/argo/issues/4187#issuecomment-1765451949 and https://github.com/sul-dlss/argo/issues/4194#issuecomment-1765450594.  In particular, the tags indexing should have been completed by now.

# How was this change tested?

- [x] CI
- [x] Ran the benchmarking in prod (without changing the current rolling indexer process)
- [x] Deployed to stage and watched honeybadger
