### PR TITLE
add contributor_text_nostem_im field for searching authors

### DIFF
--- a/app/indexers/descriptive_metadata_indexer.rb
+++ b/app/indexers/descriptive_metadata_indexer.rb
@@ -20,7 +20,9 @@ class DescriptiveMetadataIndexer
       'mods_typeOfResource_ssim' => resource_type,
       'sw_format_ssim' => sw_format,
       'sw_genre_ssim' => stanford_mods_record.sw_genre,
-      'sw_author_tesim' => author,
+      'contributor_text_nostem_im' => author_all, # author names should be tokenized but not stemmed
+      'author_text_nostem_im' => author_primary, # primary author tokenized but not stemmed
+      'sw_author_tesim' => author_primary,
       'contributor_orcids_ssim' => orcids,
       'sw_display_title_tesim' => title,
       'sw_subject_temporal_ssim' => stanford_mods_record.era_facet,
@@ -53,8 +55,16 @@ class DescriptiveMetadataIndexer
     @subjects ||= Array(cocina.description.subject)
   end
 
-  def author
-    AuthorBuilder.build(Array(cocina.description.contributor))
+  def author_primary
+    author_builder.build_primary
+  end
+
+  def author_all
+    author_builder.build_all
+  end
+
+  def author_builder
+    @author_builder ||= AuthorBuilder.new(Array(cocina.description.contributor))
   end
 
   def orcids

--- a/app/services/author_builder.rb
+++ b/app/services/author_builder.rb
@@ -1,34 +1,26 @@
 # frozen_string_literal: true
 
 class AuthorBuilder
-  ALLOWED_ROLES = %w[Author creator].freeze
-
-  # @param [Array<Cocina::Models::Contributor>] contributors
-  # @return [String] the author value for Solr
-  def self.build(contributors)
-    new(contributors).build
+  def initialize(cocina_contributors)
+    @cocina_contributors = Array(cocina_contributors)
   end
 
-  def initialize(contributors)
-    @contributors = Array(contributors)
+  def build_primary
+    contributor = primary_cocina_contributor || cocina_contributors.first
+    return unless contributor
+
+    NameBuilder.build_primary_name(contributor.name) if contributor
   end
 
-  def build
-    contributor = primary_contributor || contributors.first
-    build_contributor(contributor)
+  def build_all
+    NameBuilder.build_all(cocina_contributors.filter_map(&:name))
   end
 
   private
 
-  attr_reader :contributors
+  attr_reader :cocina_contributors
 
-  def build_contributor(contributor)
-    return if contributor.nil?
-
-    NameBuilder.build(contributor.name).first
-  end
-
-  def primary_contributor
-    contributors.find { |contributor| contributor.status == 'primary' }
+  def primary_cocina_contributor
+    cocina_contributors.find { |cocina_contributor| cocina_contributor.status == 'primary' }
   end
 end

--- a/app/services/name_builder.rb
+++ b/app/services/name_builder.rb
@@ -3,13 +3,21 @@
 class NameBuilder
   # @param [Symbol] strategy ":first" is the strategy for how to choose a name if primary and display name is not found
   # @return [Array<String>] names
-  def self.build(names, strategy: :first)
+  def self.build_all(cocina_contributors)
+    flat_names = cocina_contributors.filter_map { |cocina_contributor| flat_names_for(cocina_contributor) }.flatten
+    flat_names.filter_map { |name| build_name(name) }
+  end
+
+  # @param [Symbol] strategy ":first" is the strategy for how to choose a name if primary and display name is not found
+  # @return [String] name
+  def self.build_primary_name(names, strategy: :first)
+    names = Array(names) unless names.is_a?(Array)
     flat_names = flat_names_for(names)
     name = display_name_for(flat_names) || primary_name_for(flat_names)
     name ||= flat_names.first if strategy == :first
-    return Array(build_name(name)) if name
+    return build_name(name) if name
 
-    flat_names.map { |one| build_name(one) }
+    flat_names.filter_map { |one| build_name(one) }.first
   end
 
   def self.build_name(name)
@@ -26,7 +34,6 @@ class NameBuilder
       joined_name = join_parts([joined_name, terms_of_address], ' ')
       joined_name = join_parts([joined_name, life_dates], ', ')
       join_parts([joined_name, activity_dates], ', ')
-
     else
       name.value
     end

--- a/spec/indexers/descriptive_metadata_indexer_contributor_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_contributor_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DescriptiveMetadataIndexer do
     )
   end
 
-  describe 'primary contributor mappings from Cocina to Solr sw_author_tesim' do
+  describe 'primary contributor mappings from Cocina to Solr contributor_text_nostem_im and sw_author_tesim' do
     ### Select contributor
     context 'when single contributor' do
       let(:description) do
@@ -37,7 +37,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects name of contributor' do
-        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.')
+        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.',
+                               'contributor_text_nostem_im' => ['Sayers, Dorothy L.'])
       end
     end
 
@@ -70,7 +71,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects name of contributor with primary status' do
-        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.')
+        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.',
+                               'contributor_text_nostem_im' => ['Sayers, Dorothy L.', 'Dunnett, Dorothy'])
       end
     end
 
@@ -102,7 +104,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects name of first contributor' do
-        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.')
+        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.',
+                               'contributor_text_nostem_im' => ['Sayers, Dorothy L.', 'Dunnett, Dorothy'])
       end
     end
 
@@ -133,7 +136,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects display name of contributor' do
-        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.')
+        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.',
+                               'contributor_text_nostem_im' => ['Sayers, Dorothy L. (Dorothy Leigh), 1893-1957', 'Sayers, Dorothy L.'])
       end
     end
 
@@ -162,7 +166,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects primary name of contributor' do
-        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.')
+        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.',
+                               'contributor_text_nostem_im' => ['Sayers, Dorothy L.', 'Sayers, Dorothy L. (Dorothy Leigh), 1893-1957'])
       end
     end
 
@@ -190,7 +195,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects first name of contributor' do
-        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.')
+        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L.',
+                               'contributor_text_nostem_im' => ['Sayers, Dorothy L.', 'Sayers, Dorothy L. (Dorothy Leigh), 1893-1957'])
       end
     end
 
@@ -223,7 +229,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects primary name from parallelValue' do
-        expect(doc).to include('sw_author_tesim' => 'Bulgakov, Mikhail Afanasʹevich')
+        expect(doc).to include('sw_author_tesim' => 'Bulgakov, Mikhail Afanasʹevich',
+                               'contributor_text_nostem_im' => ['Булгаков, Михаил Афанасьевич', 'Bulgakov, Mikhail Afanasʹevich'])
       end
     end
 
@@ -255,7 +262,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects first name from parallelValue' do
-        expect(doc).to include('sw_author_tesim' => 'Булгаков, Михаил Афанасьевич')
+        expect(doc).to include('sw_author_tesim' => 'Булгаков, Михаил Афанасьевич',
+                               'contributor_text_nostem_im' => ['Булгаков, Михаил Афанасьевич', 'Bulgakov, Mikhail Afanasʹevich'])
       end
     end
 
@@ -289,7 +297,8 @@ RSpec.describe DescriptiveMetadataIndexer do
       end
 
       it 'selects value with type name' do
-        expect(doc).to include('sw_author_tesim' => 'Strachey, Dorothy')
+        expect(doc).to include('sw_author_tesim' => 'Strachey, Dorothy',
+                               'contributor_text_nostem_im' => ['Strachey, Dorothy'])
       end
     end
 
@@ -352,7 +361,9 @@ RSpec.describe DescriptiveMetadataIndexer do
 
       it 'constructs name of contributor' do
         # No comma between name and term of address because also used for e.g. Elizabeth I
-        expect(doc).to include('sw_author_tesim' => 'Sayers Fleming, Dorothy Leigh B.A. (Oxon.), M.A. (Oxon.), 1893-1957')
+        expected_value = 'Sayers Fleming, Dorothy Leigh B.A. (Oxon.), M.A. (Oxon.), 1893-1957'
+        expect(doc).to include('sw_author_tesim' => expected_value,
+                               'contributor_text_nostem_im' => [expected_value])
       end
     end
 
@@ -398,7 +409,9 @@ RSpec.describe DescriptiveMetadataIndexer do
 
       it 'constructs name of contributor' do
         # No comma between name and term of address because also used for e.g. Elizabeth I
-        expect(doc).to include('sw_author_tesim' => 'Sayers, Dorothy L. B.A. (Oxon.), M.A. (Oxon.), 1893-1957')
+        expected_value = 'Sayers, Dorothy L. B.A. (Oxon.), M.A. (Oxon.), 1893-1957'
+        expect(doc).to include('sw_author_tesim' => expected_value,
+                               'contributor_text_nostem_im' => [expected_value])
       end
     end
 
@@ -433,7 +446,9 @@ RSpec.describe DescriptiveMetadataIndexer do
 
       it 'constructs name of contributor' do
         # Concatenate in order given, period space delimiter
-        expect(doc).to include('sw_author_tesim' => 'United States. Office of Foreign Investment in the United States')
+        expected_value = 'United States. Office of Foreign Investment in the United States'
+        expect(doc).to include('sw_author_tesim' => expected_value,
+                               'contributor_text_nostem_im' => [expected_value])
       end
     end
   end

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -396,6 +396,8 @@ RSpec.describe DescriptiveMetadataIndexer do
         'sw_subject_geographic_ssim' => ['Europe'],
         'sw_pub_date_facet_ssi' => '1911',
         'sw_author_tesim' => 'George, Henry, 1839-1897',
+        'author_text_nostem_im' => 'George, Henry, 1839-1897',
+        'contributor_text_nostem_im' => ['George, Henry, 1839-1897', 'George, Henry, 1862-1916', 'George, Bush', 'Wiles, Simon'],
         'sw_display_title_tesim' => 'The complete works of Henry George',
         # 'originInfo_date_created_tesim' => '', # not populated by the example; see indexer_spec instead
         'originInfo_publisher_tesim' => 'Doubleday, Page',


### PR DESCRIPTION
## Why was this change made? 🤔

Part of sul-dlss/argo#4231

For better searching recall and precision.  In argo prod right now, there is very poor recall for searching on author names.

## How was this change tested? 🤨

CI. (we're just adding a new field to the index)



