### PR TITLE
Spruce up, and dial back, rolling indexer

### DIFF
--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -4,18 +4,27 @@ require_relative '../config/environment'
 require 'daemons'
 require 'parallel'
 
-QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id', rows: '500' }
+QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id', rows: Settings.rolling_indexer.batch_size }
 
-Daemons.run_proc('rolling index') do
+Daemons.run_proc(
+  File.basename(__FILE__),
+  dir: "tmp/pids",
+  log_dir: "#{File.expand_path(__dir__)}/../log",
+  log_output: true,
+  logfilename: 'rolling_index.log',
+  output_logfilename: 'rolling_index.log'
+) do
   loop do
+    start_time = Time.now
+
     solr_conn = RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
     response = solr_conn.get 'select', params: QUERY
-    solr_docs = Parallel.map(response['response']['docs'], in_processes: 8) do |doc|
+    solr_docs = Parallel.map(response['response']['docs'], in_processes: Settings.rolling_indexer.processes) do |doc|
       identifier = doc['id'].scrub('')
       # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
       Honeybadger.notify("Identifier isn't valid utf-8", { identifier: identifier, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
       begin
-        # This returns a Solr doc instance
+        # This returns a Solr doc hash
         Indexer.load_and_build(identifier: identifier)
       rescue Dor::Services::Client::NotFoundResponse
         Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
@@ -29,7 +38,14 @@ Daemons.run_proc('rolling index') do
         nil
       end
     end.compact
+
     solr_conn.add(solr_docs, add_attributes: { commitWithin: 1000 })
-    sleep(5) # This was just a wild guess.  We can turn this up/down as necessary.
+
+    end_time = Time.now
+    batch_run_seconds = (end_time - start_time).round(3)
+    # The Daemons gem will redirect this to its log
+    puts "#{end_time}\tIndexed #{Settings.rolling_indexer.batch_size} documents in #{batch_run_seconds}"
+
+    sleep(Settings.rolling_indexer.pause_time_between_batches)
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,9 @@
 # General
 date_format_str: '%Y-%m-%d %H:%M:%S.%L'
+rolling_indexer:
+  processes: 2
+  batch_size: 500
+  pause_time_between_batches: 5 # This is a wild guess. We can turn this up/down as necessary.
 
 ssl:
   cert_file: ~
@@ -18,7 +22,6 @@ workflow_url: 'https://workflow.example.edu/'
 dor_services:
   url: 'http://localhost:3003'
   token: 'not-a-real-token'
-
 
 rabbitmq:
   hostname: localhost


### PR DESCRIPTION
# Why was this change made?

This commit makes the following changes to the rolling indexer:

* Limit parallelization within the indexer to 2 processes so we don't take down services under load
* Replace magic numbers in rolling indexer with values from settings for easier per-env
* Enable logging within rolling indexer
* Write pidfile to a fixed location for easier management of the rolling_index process
* Log the total runtime of each iteration of the rolling indexer

# How was this change tested?

- [x] CI
- [x] Deployed to stage, restarted indexer, watched log, saw expected output:

```
2023-10-18 12:11:16 -0700       Indexed 500 documents in 34.766
2023-10-18 12:11:56 -0700       Indexed 500 documents in 34.877
2023-10-18 12:12:36 -0700       Indexed 500 documents in 35.325
2023-10-18 12:13:17 -0700       Indexed 500 documents in 35.562
2023-10-18 12:13:59 -0700       Indexed 500 documents in 35.156
```

So this is running a bit more quickly than perhaps we expected, and maybe the 2x improvement is sufficient?