### PR TITLE
remove exploded_tag_ssim as it is no longer used

### DIFF
--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -18,13 +18,12 @@ class AdministrativeTagIndexer
   def to_solr
     Rails.logger.debug { "In #{self.class}" }
 
-    solr_doc = { 'tag_ssim' => [], 'exploded_tag_ssim' => [], 'exploded_nonproject_tag_ssim' => [] }
+    solr_doc = { 'tag_ssim' => [], 'exploded_nonproject_tag_ssim' => [] }
     administrative_tags.each do |tag|
       tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
       prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
 
       solr_doc['tag_ssim'] << tag
-      solr_doc['exploded_tag_ssim'] += exploded_tags_from(tag) # deprecated; facet field to be replaced by other exploded_xxx_tag fields
 
       solr_doc['exploded_nonproject_tag_ssim'] += exploded_tags_from(tag) unless prefix == 'project'
 

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -27,10 +27,6 @@ RSpec.describe AdministrativeTagIndexer do
     end
 
     it 'indexes exploded tags' do
-      expect(document['exploded_tag_ssim']).to contain_exactly('Google Books', 'Google Books : Phase 1', 'Google Books', 'Google Books : Scan source STANFORD', 'Project',
-                                                               'Project : Beautiful Books', 'Project', 'Project : Rare Books', 'Project : Rare Books : Very Old Books', 'Registered By',
-                                                               'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books', 'DPG : Beautiful Books : Octavo',
-                                                               'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
       expect(document['exploded_nonproject_tag_ssim']).to contain_exactly('Google Books', 'Google Books : Phase 1', 'Google Books', 'Google Books : Scan source STANFORD',
                                                                           'Registered By',
                                                                           'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books', 'DPG : Beautiful Books : Octavo',


### PR DESCRIPTION
## Why was this change made? 🤔

- Getting rid of cruft
- freeing up space on sul-solr boxes (exploded tags are stored and are large fields)

Closes #1025 
Part of #1047

## How was this change tested? 🤨

- github search on sul-dlss repos to make sure tag isn't used https://github.com/search?q=org%3Asul-dlss+exploded_tag_ssim&type=code
- CI
- sul-dlss/infrastructure-integration-test/pull/650

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



