### PR TITLE
Reduce rolling indexer processes to 1

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 # General
 date_format_str: '%Y-%m-%d %H:%M:%S.%L'
 rolling_indexer:
-  processes: 2
+  processes: 1
   batch_size: 500
   pause_time_between_batches: 5 # This is a wild guess. We can turn this up/down as necessary.
 


### PR DESCRIPTION
## Why was this change made? 🤔
To rule this out as contributing to DSA problems.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



