### PR TITLE
deal with another alternate orcid format for contributors

### DIFF
--- a/app/services/orcid_builder.rb
+++ b/app/services/orcid_builder.rb
@@ -48,6 +48,9 @@ class OrcidBuilder
     return identifier.uri if identifier.uri
     return identifier.value if identifier.value.start_with?('https://orcid.org/')
 
+    # some records have just the ORCIDID without the URL prefix, add it if so, e.g. druid:tp865ng1792
+    return URI.join('https://orcid.org/', identifier.value).to_s if identifier.source.uri.blank?
+
     URI.join(identifier.source.uri, identifier.value).to_s
   end
 end

--- a/app/services/orcid_builder.rb
+++ b/app/services/orcid_builder.rb
@@ -48,9 +48,6 @@ class OrcidBuilder
     return identifier.uri if identifier.uri
     return identifier.value if identifier.value.start_with?('https://orcid.org/')
 
-    # some records have just the ORCIDID without the URL prefix, add it if so, e.g. druid:tp865ng1792
-    return URI.join('https://orcid.org/', identifier.value).to_s if identifier.source.uri.blank?
-
-    URI.join(identifier.source.uri, identifier.value).to_s
+    URI.join('https://orcid.org/', identifier.value).to_s
   end
 end

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           ],
           identifier: [
             {
-              value: 'https://orcid.org/0000-0001-5321-289X',
+              value: '0000-0001-5321-289X',
               type: 'ORCID',
               source: {
                 code: 'orcid'


### PR DESCRIPTION
## Why was this change made? 🤔

Same thing as https://github.com/sul-dlss/orcid_client/pull/30, i.e. we have varying formats of how ORCIDs are represented in contributors. This deals with another case that caused https://app.honeybadger.io/projects/50568/faults/102209790

We also needed to add to orcid_client until we consolidate as described in https://github.com/sul-dlss/dor_indexing_app/issues/1022

## How was this change tested? 🤨

Updated spec



