### PR TITLE
Re-calibrate the rolling indexer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'iso-639', '~> 0.3.5'
 gem 'language_list'
 gem 'marc-vocab', '~> 0.3.0'
 gem 'okcomputer' # for monitoring
-gem 'parallel'
 gem 'puma', '~> 5.3' # app server
 gem 'rack-timeout', '~> 0.5.1'
 gem 'rails', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,6 @@ DEPENDENCIES
   listen (~> 3.0.5)
   marc-vocab (~> 0.3.0)
   okcomputer
-  parallel
   parse_date
   puma (~> 5.3)
   rack-timeout (~> 0.5.1)

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -2,7 +2,6 @@
 
 require_relative '../config/environment'
 require 'daemons'
-require 'parallel'
 
 QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id', rows: Settings.rolling_indexer.batch_size }
 
@@ -19,7 +18,7 @@ Daemons.run_proc(
 
     solr_conn = RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
     response = solr_conn.get 'select', params: QUERY
-    solr_docs = Parallel.map(response['response']['docs'], in_processes: Settings.rolling_indexer.processes) do |doc|
+    solr_docs = response['response']['docs'].map do |doc|
       identifier = doc['id'].scrub('')
       # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
       Honeybadger.notify("Identifier isn't valid utf-8", { identifier: identifier, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
@@ -36,6 +35,8 @@ Daemons.run_proc(
         Honeybadger.notify('Unexpected response from Dor Services App.', { druid: identifier })
         # Return `nil`, which is compacted, so the Solr add isn't grumpy
         nil
+      ensure
+        sleep(Settings.rolling_indexer.pause_time_between_docs)
       end
     end.compact
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,9 +1,9 @@
 # General
 date_format_str: '%Y-%m-%d %H:%M:%S.%L'
 rolling_indexer:
-  processes: 1
   batch_size: 500
-  pause_time_between_batches: 5 # This is a wild guess. We can turn this up/down as necessary.
+  pause_time_between_docs: .2
+  pause_time_between_batches: 0
 
 ssl:
   cert_file: ~


### PR DESCRIPTION
## Why was this change made? 🤔
To slow down the rolling indexer is configurable ways.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

QA


