### PR TITLE
allow sandbox URIs in test data to be returned

### DIFF
--- a/app/services/orcid_builder.rb
+++ b/app/services/orcid_builder.rb
@@ -48,6 +48,9 @@ class OrcidBuilder
     return identifier.uri if identifier.uri
     return identifier.value if identifier.value.start_with?('https://orcid.org/')
 
-    URI.join('https://orcid.org/', identifier.value).to_s
+    # some records have just the ORCIDID without the URL prefix, add it if so, e.g. druid:tp865ng1792
+    return URI.join('https://orcid.org/', identifier.value).to_s if identifier.source.uri.blank?
+
+    URI.join(identifier.source.uri, identifier.value).to_s
   end
 end

--- a/spec/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/indexers/descriptive_metadata_indexer_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe DescriptiveMetadataIndexer do
           type: 'person',
           identifier: [
             {
-              uri: 'https://orcid.org/1111-2222-3333-4444',
+              uri: 'https://sandbox.orcid.org/1111-2222-3333-4444',
               type: 'ORCID',
               source: {
                 code: 'orcid'
@@ -404,7 +404,7 @@ RSpec.describe DescriptiveMetadataIndexer do
         'originInfo_place_placeTerm_tesim' => 'Garden City, N. Y',
         'topic_ssim' => %w[Economics cats],
         'topic_tesim' => %w[cats Economics],
-        'contributor_orcids_ssim' => ['https://orcid.org/0000-1111-2222-3333', 'https://orcid.org/1111-2222-3333-4444', 'https://orcid.org/0000-0001-5321-289X']
+        'contributor_orcids_ssim' => ['https://orcid.org/0000-1111-2222-3333', 'https://sandbox.orcid.org/1111-2222-3333-4444', 'https://orcid.org/0000-0001-5321-289X']
       )
     end
     # rubocop:enable Style/StringHashKeys


### PR DESCRIPTION
## Why was this change made? 🤔

Same change as https://github.com/sul-dlss/orcid_client/pull/32 --- rollback part of the work done in #1059 so that sandbox ORCID's can still be present in test data and represented correctly.

## How was this change tested? 🤨

Updated a spec to verify it works as expected