### PR TITLE
searchable tags: index to Solr field tag_text_unstemmed_sim

### DIFF
--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -15,15 +15,20 @@ class AdministrativeTagIndexer
   end
 
   # @return [Hash] the partial solr document for administrative tags
-  def to_solr
+  def to_solr # rubocop:disable Metrics/MethodLength
     Rails.logger.debug { "In #{self.class}" }
 
-    solr_doc = { 'tag_ssim' => [], 'exploded_nonproject_tag_ssim' => [] }
+    solr_doc = {
+      'tag_ssim' => [], # deprecated in favor of tag_text_unstemmed_sim for searchability
+      'tag_text_unstemmed_sim' => [],
+      'exploded_nonproject_tag_ssim' => []
+    }
     administrative_tags.each do |tag|
       tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
       prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
 
-      solr_doc['tag_ssim'] << tag
+      solr_doc['tag_ssim'] << tag # deprecated in favor of tag_text_unstemmed_sim for searchability
+      solr_doc['tag_text_unstemmed_sim'] << tag
 
       solr_doc['exploded_nonproject_tag_ssim'] += exploded_tags_from(tag) unless prefix == 'project'
 

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe AdministrativeTagIndexer do
 
     it 'indexes all administrative tags' do
       # rubocop:disable Style/StringHashKeys
-      expect(document).to include('tag_ssim' => tags)
+      expect(document).to include('tag_ssim' => tags) # Deprecated in favor of tag_text_unstemmed_sim for searchability
+      expect(document).to include('tag_text_unstemmed_sim' => tags)
       # rubocop:enable Style/StringHashKeys
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of  sul-dlss/argo/issues/4265

To make tags more searchable, they need to be tokenized.   The new field, once populated and set up in Argo, will replace `tag_ssim`

## How was this change tested? 🤨

CI


