### PR TITLE
only store one flavor of un-exploded tags

### DIFF
--- a/app/indexers/administrative_tag_indexer.rb
+++ b/app/indexers/administrative_tag_indexer.rb
@@ -19,16 +19,16 @@ class AdministrativeTagIndexer
     Rails.logger.debug { "In #{self.class}" }
 
     solr_doc = {
-      'tag_ssim' => [], # deprecated in favor of tag_text_unstemmed_sim for searchability
-      'tag_text_unstemmed_sim' => [],
+      'tag_ssim' => [],
+      'tag_text_unstemmed_im' => [],
       'exploded_nonproject_tag_ssim' => []
     }
     administrative_tags.each do |tag|
       tag_prefix, rest = tag.split(TAG_PART_DELIMITER, 2)
       prefix = tag_prefix.downcase.strip.gsub(/\s/, '_')
 
-      solr_doc['tag_ssim'] << tag # deprecated in favor of tag_text_unstemmed_sim for searchability
-      solr_doc['tag_text_unstemmed_sim'] << tag
+      solr_doc['tag_ssim'] << tag # for facet and display
+      solr_doc['tag_text_unstemmed_im'] << tag # for search
 
       solr_doc['exploded_nonproject_tag_ssim'] += exploded_tags_from(tag) unless prefix == 'project'
 

--- a/spec/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/indexers/administrative_tag_indexer_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe AdministrativeTagIndexer do
 
     it 'indexes all administrative tags' do
       # rubocop:disable Style/StringHashKeys
-      expect(document).to include('tag_ssim' => tags) # Deprecated in favor of tag_text_unstemmed_sim for searchability
-      expect(document).to include('tag_text_unstemmed_sim' => tags)
+      expect(document).to include('tag_ssim' => tags) # for facet and display
+      expect(document).to include('tag_text_unstemmed_im' => tags) # for search
       # rubocop:enable Style/StringHashKeys
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

To fix a previous mistake of mine - we will need both `tag_ssim` and a searchable tag field.

## How was this change tested? 🤨

CI




