### PR TITLE
cap deploy log includes status of rolling indexer after start

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ set :sneakers_systemd_use_hooks, true
 before 'deploy:restart', 'shared_configs:update'
 
 # Tasks for managing the rolling indexer
-namespace :rolling_indexer do
+namespace :rolling_indexer do # rubocop:disable Metrics/BlockLength
   desc 'Stop rolling indexer'
   task :stop do
     on roles(:rolling_indexer) do
@@ -37,6 +37,7 @@ namespace :rolling_indexer do
   task :start do
     on roles(:rolling_indexer) do
       sudo :systemctl, 'start', 'rolling-index'
+      sudo :systemctl, 'status', 'rolling-index'
     end
   end
 
@@ -44,6 +45,7 @@ namespace :rolling_indexer do
   task :restart do
     on roles(:rolling_indexer) do
       sudo :systemctl, 'restart', 'rolling-index', raise_on_non_zero_exit: false
+      sudo :systemctl, 'status', 'rolling-index'
     end
   end
 
@@ -55,6 +57,6 @@ namespace :rolling_indexer do
   end
 end
 
-after 'deploy:failed', 'rolling_indexer:restart'
-after 'deploy:published', 'rolling_indexer:start'
 after 'deploy:starting', 'rolling_indexer:stop'
+after 'deploy:published', 'rolling_indexer:start'
+after 'deploy:failed', 'rolling_indexer:restart'


### PR DESCRIPTION
## Why was this change made? 🤔

I thought this might bring more awareness to the fact that the rolling_indexer should be running, and give more confirmation.  An argument can be made that this is NOT useful.   I didn't realize we had capistrano tasks for the rolling_indexer.  Maybe everyone else knows that.  Maybe this isn't a way to raise awareness.  

### Capistrano log in my terminal window AFTER
```
      01 Restarting /opt/app/dor_indexer/dor_indexing_app/current (production)
    ✔ 01 dor_indexer@dor-indexing-app-qa-b.stanford.edu 0.310s
01:55 rolling_indexer:start
      01 sudo systemctl start rolling-index
    ✔ 01 dor_indexer@dor-indexing-app-qa-a.stanford.edu 1.600s
      02 sudo systemctl status rolling-index
      02 ● rolling-index.service - rolling-index
      02      Loaded: loaded (/etc/systemd/system/rolling-index.service; enabled; vendor preset: enabled)
      02      Active: active (running) since Mon 2024-01-08 12:21:57 PST; 171ms ago
      02     Process: 2991935 ExecStart=/bin/bash -lc exec bin/rolling_index start (code=exited, status=0/SUCCESS)
      02    Main PID: 2992029 (ruby)
      02       Tasks: 2 (limit: 9475)
      02      Memory: 102.1M
      02      CGroup: /system.slice/rolling-index.service
      02              └─2992029 rolling_index
      02
      02 Jan 08 12:21:56 dor-indexing-app-qa-a.stanford.edu systemd[1]: Starting rolling-index...
      02 Jan 08 12:21:57 dor-indexing-app-qa-a.stanford.edu bash[2991935]: [DEPRECATION] openapi_parser will default to strict reference validation from next version. Pass config `strict_reference_vali…
      02 Jan 08 12:21:57 dor-indexing-app-qa-a.stanford.edu bash[2991935]: rolling_index: process with pid 2992029 started.
      02 Jan 08 12:21:57 dor-indexing-app-qa-a.stanford.edu systemd[1]: Started rolling-index.
    ✔ 02 dor_indexer@dor-indexing-app-qa-a.stanford.edu 0.194s
01:57 sneakers_systemd:start
      01 sudo systemctl start sneakers
```

### Capistrano log in my terminal window BEFORE
```
      01 Restarting /opt/app/dor_indexer/dor_indexing_app/current (production)
    ✔ 01 dor_indexer@dor-indexing-app-qa-b.stanford.edu 0.302s
01:55 rolling_indexer:start
      01 sudo systemctl start rolling-index
    ✔ 01 dor_indexer@dor-indexing-app-qa-a.stanford.edu 1.441s
01:57 sneakers_systemd:start
      01 sudo systemctl start sneakers
```

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



