### PR TITLE
rolling re-index performance improvements

### DIFF
--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -18,6 +18,9 @@ Daemons.run_proc(
 
     solr_conn = RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
     response = solr_conn.get 'select', params: QUERY
+
+    have_response_time = Time.now
+
     solr_docs = response['response']['docs'].map do |doc|
       identifier = doc['id'].scrub('')
       # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
@@ -39,6 +42,10 @@ Daemons.run_proc(
         sleep(Settings.rolling_indexer.pause_time_between_docs)
       end
     end.compact
+
+    build_docs_time = Time.now
+    # The Daemons gem will redirect this to its log
+    puts "#{build_docs_time}\tGot oldest ids from Solr in #{(have_response_time - start_time).round(3)}; Built Solr docs in #{(build_docs_time - have_response_time).round(3)}"
 
     solr_conn.add(solr_docs, add_attributes: { commitWithin: Settings.rolling_indexer.commit_within.to_i })
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,6 @@ workflow:
   shift_age: 'weekly'
   timeout: 60
 
-fedora_url: 'https://user:password@fedora.example.com:1000/fedora'
 solrizer_url: 'https://solr.example.com/solr/collection'
 workflow_url: 'https://workflow.example.edu/'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,12 +2,12 @@
 date_format_str: '%Y-%m-%d %H:%M:%S.%L'
 rolling_indexer:
   batch_size: 500
-  # in seconds
-  pause_time_between_docs: 0.2
-  # commitWithin does a soft commit by default, so a little more than commitWithin is desired (seconds)
-  pause_time_between_batches: 11
+  # avoid overloading the load balancer (seconds)
+  pause_time_between_docs: 0.1
+  # a little more than softCommit max time is desired (a Solr 'add' with commitWithin does a softCommit) (seconds)
+  pause_time_between_batches: 5.1
   # milliseconds
-  commitWithin: 1000
+  commitWithin: 500
 
 ssl:
   cert_file: ~


### PR DESCRIPTION
## Why was this change made? 🤔

See #1082 and sul-dlss/sul-solr-configs/pull/288

To make reindexing all the SDR objects for Argo significantly faster.

And to joyously remove the fedora_url from the settings.

## How was this change tested? 🤨

In argo_prod, watching the rolling_index.log and watching honeybadger for errors in DIA or DSA




