### PR TITLE
stop indexing to source_id_ssim, now that source_id_ssi is populated

### DIFF
--- a/app/indexers/identity_metadata_indexer.rb
+++ b/app/indexers/identity_metadata_indexer.rb
@@ -17,7 +17,6 @@ class IdentityMetadataIndexer
       'identifier_ssim' => prefixed_identifiers,
       'identifier_tesim' => prefixed_identifiers,
       'barcode_id_ssim' => [barcode].compact,
-      'source_id_ssim' => [source_id].compact, # deprecated; waiting for new fields to populate
       'source_id_ssi' => source_id,
       'source_id_text_nostem_i' => source_id,
       'folio_instance_hrid_ssim' => [folio_instance_hrid].compact,

--- a/spec/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/indexers/identity_metadata_indexer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe IdentityMetadataIndexer do
           'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                                  'folio:a129483625'],
           'objectType_ssim' => ['item'],
-          'source_id_ssim' => ['google:STANFORD_342837261527'],
+          'source_id_ssi' => 'google:STANFORD_342837261527',
           'doi_ssim' => ['10.25740/yr775yn6440']
         )
       end
@@ -77,7 +77,6 @@ RSpec.describe IdentityMetadataIndexer do
           'identifier_ssim' => ['sul:1234'],
           'identifier_tesim' => ['sul:1234'],
           'objectType_ssim' => ['agreement'],
-          'source_id_ssim' => ['sul:1234'],
           'source_id_ssi' => 'sul:1234',
           'source_id_text_nostem_i' => 'sul:1234'
         )
@@ -115,7 +114,6 @@ RSpec.describe IdentityMetadataIndexer do
           'identifier_ssim' => ['google:STANFORD_342837261527', 'folio:a129483625'],
           'identifier_tesim' => ['google:STANFORD_342837261527', 'folio:a129483625'],
           'objectType_ssim' => ['collection'],
-          'source_id_ssim' => ['google:STANFORD_342837261527'],
           'source_id_ssi' => 'google:STANFORD_342837261527',
           'source_id_text_nostem_i' => 'google:STANFORD_342837261527'
         )


### PR DESCRIPTION
## Why was this change made? 🤔

Final cleanup from sul-dlss/argo/issues/4194

## How was this change tested? 🤨

searched cloned git repos locally and used github to search sul-dlss to find all occurrences of `source_id_ssim`.  This is it.  https://github.com/search?q=org%3Asul-dlss%20source_id_ssim&type=code

