### PR TITLE
Change looping strategy for rolling indexer.

### DIFF
--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -3,7 +3,7 @@
 require_relative '../config/environment'
 require 'daemons'
 
-QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id,timestamp', rows: Settings.rolling_indexer.batch_size }
+QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id,timestamp', rows: Settings.rolling_indexer.query_size }
 
 Daemons.run_proc(
   File.basename(__FILE__),
@@ -18,39 +18,43 @@ Daemons.run_proc(
 
     solr_conn = RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solrizer_url)
     response = solr_conn.get 'select', params: QUERY
-    solr_docs = response['response']['docs'].map do |doc|
-      identifier = doc['id'].scrub('')
-      # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
-      Honeybadger.notify("Identifier isn't valid utf-8", { identifier: identifier, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
-      begin
-        # This returns a Solr doc hash
-        Indexer.load_and_build(identifier: identifier)
-      rescue Dor::Services::Client::NotFoundResponse
-        Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
-        # Clean up cruft in QA and stage
-        Indexer.delete(solr: solr_conn, identifier: identifier) if ['stage', 'qa'].include?(ENV['HONEYBADGER_ENV'])
-        # Return `nil`, which is compacted, so the Solr add isn't grumpy
-        nil
-      rescue Dor::Services::Client::UnexpectedResponse
-        Honeybadger.notify('Unexpected response from Dor Services App.', { druid: identifier })
-        # Return `nil`, which is compacted, so the Solr add isn't grumpy
-        nil
-      ensure
-        sleep(Settings.rolling_indexer.pause_time_between_docs)
-      end
-    end.compact
+    batches = response['response']['docs'].each_slice(Settings.rolling_indexer.batch_size)
 
-    solr_conn.add(solr_docs, add_attributes: { commitWithin: Settings.rolling_indexer.commit_within.to_i })
+    batches.each.with_index do |batch, index|
+      solr_docs = batch.map do |doc|
+        identifier = doc['id'].scrub('')
+        # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
+        Honeybadger.notify("Identifier isn't valid utf-8", { identifier: identifier, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
+        begin
+          # This returns a Solr doc hash
+          Indexer.load_and_build(identifier: identifier)
+        rescue Dor::Services::Client::NotFoundResponse
+          Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
+          # Clean up cruft in QA and stage
+          Indexer.delete(solr: solr_conn, identifier: identifier) if ['stage', 'qa'].include?(ENV['HONEYBADGER_ENV'])
+          # Return `nil`, which is compacted, so the Solr add isn't grumpy
+          nil
+        rescue Dor::Services::Client::UnexpectedResponse
+          Honeybadger.notify('Unexpected response from Dor Services App.', { druid: identifier })
+          # Return `nil`, which is compacted, so the Solr add isn't grumpy
+          nil
+        ensure
+          sleep(Settings.rolling_indexer.pause_time_between_docs)
+        end
+      end.compact
 
-    end_time = Time.now
-    batch_run_seconds = (end_time - start_time).round(3)
-    first_doc = response['response']['docs'].first
-    first_doc_str = "#{first_doc['id']} (#{first_doc['timestamp']})"
-    last_doc = response['response']['docs'].last
-    last_doc_str = "#{last_doc['id']} (#{last_doc['timestamp']})"
-    # The Daemons gem will redirect this to its log
-    puts "#{end_time}\tIndexed #{Settings.rolling_indexer.batch_size} documents in #{batch_run_seconds}\t#{first_doc_str} - #{last_doc_str}"
+      solr_conn.add(solr_docs, add_attributes: { commitWithin: Settings.rolling_indexer.commit_within.to_i })
 
-    sleep(Settings.rolling_indexer.pause_time_between_batches)
+      end_time = Time.now
+      batch_run_seconds = (end_time - start_time).round(3)
+      first_doc = response['response']['docs'].first
+      first_doc_str = "#{first_doc['id']} (#{first_doc['timestamp']})"
+      last_doc = response['response']['docs'].last
+      last_doc_str = "#{last_doc['id']} (#{last_doc['timestamp']})"
+      # The Daemons gem will redirect this to its log
+      puts "#{end_time}\tIndexed #{Settings.rolling_indexer.batch_size} documents in #{batch_run_seconds}\t#{first_doc_str} - #{last_doc_str}"
+    end
+    # Pause for the last batch so that solr can commit before querying it again.
+    sleep(Settings.rolling_indexer.pause_for_solr) if index == batches.size - 1
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,11 +1,12 @@
 # General
 date_format_str: '%Y-%m-%d %H:%M:%S.%L'
 rolling_indexer:
+  query_size: 100000
   batch_size: 500
   # avoid overloading the load balancer (seconds)
   pause_time_between_docs: 0.1
   # a little more than softCommit max time is desired (a Solr 'add' with commitWithin does a softCommit) (seconds)
-  pause_time_between_batches: 5.1
+  pause_for_solr: 10
   # milliseconds
   commitWithin: 500
 


### PR DESCRIPTION
closes #1086

## Why was this change made? 🤔
Make rolling indexer faster.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

QA

