### PR TITLE
rolling indexer settings: default to local testing numbers

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,12 +1,15 @@
 # General
 date_format_str: '%Y-%m-%d %H:%M:%S.%L'
 rolling_indexer:
-  query_size: 100000
-  batch_size: 500
-  # avoid overloading the load balancer (seconds)
+  # number of ids to get from Solr in a query
+  query_size: 100
+  # number of docs to send to Solr in a batch
+  batch_size: 5
+  # avoid overloading the dor-services-app load balancer (seconds)
   pause_time_between_docs: 0.1
   # a little more than softCommit max time is desired (a Solr 'add' with commitWithin does a softCommit) (seconds)
-  pause_for_solr: 10
+  # see solrconfig.xml for softCommit max time
+  pause_for_solr: 61
   # milliseconds
   commitWithin: 500
 


### PR DESCRIPTION
## Why was this change made? 🤔

Our settings file should be configured more for local testing than for production.

I have already made the appropriate changes to shared_configs for prod.

## How was this change tested? 🤨

n/a


