### PR TITLE
use dor_indexing v1.2.0 and cocina-models 0.94.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sneakers', '~> 2.11'
 gem 'solrizer'
 
 # DLSS gems
-gem 'dor_indexing', '~> 1.1'
+gem 'dor_indexing', '~> 1.1', '>= 1.2.0'
 gem 'dor-services-client', '~> 14.1'
 gem 'dor-workflow-client', '~> 7.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     capistrano-passenger (0.2.1)
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
-    cocina-models (0.94.0)
+    cocina-models (0.94.2)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -154,8 +154,9 @@ GEM
       faraday-retry (~> 2.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    dor_indexing (1.1.1)
-      cocina-models (~> 0.94.0)
+    dor_indexing (1.2.0)
+      cocina-models (~> 0.94.1)
+      dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
       solrizer
@@ -463,7 +464,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services-client (~> 14.1)
   dor-workflow-client (~> 7.0)
-  dor_indexing (~> 1.1)
+  dor_indexing (~> 1.1, >= 1.2.0)
   dry-monads (~> 1.3)
   erubis
   faraday


### PR DESCRIPTION
## Why was this change made? 🤔

To get new title indexing in dor_indexing gem 1.2.0, which uses new methods in cocina-models 0.94.2

## How was this change tested? 🤨

CI is enough - we're just indexing a few new title fields.



