### PR TITLE
Gemfile: simplify dor_indexing version specification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sneakers', '~> 2.11'
 gem 'solrizer'
 
 # DLSS gems
-gem 'dor_indexing', '~> 1.1', '>= 1.2.0'
+gem 'dor_indexing', '~> 1.2'
 gem 'dor-services-client', '~> 14.1'
 gem 'dor-workflow-client', '~> 7.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services-client (~> 14.1)
   dor-workflow-client (~> 7.0)
-  dor_indexing (~> 1.1, >= 1.2.0)
+  dor_indexing (~> 1.2)
   dry-monads (~> 1.3)
   erubis
   faraday


### PR DESCRIPTION
## Why was this change made? 🤔

i'm pretty sure that what's there can be stated a bit more simply, [explanation from a random stackoverflow denizen](https://stackoverflow.com/a/5170592):

> It means "equal to or greater than in the last digit", so e.g. `~> 2.3` means "equal to 2.3 or greater than 2.3, but less than 3.0", while `~> 2.3.0` would mean "equal to 2.3.0 or greater than 2.3.0, but less than 2.4.0".

## How was this change tested? 🤨

`bundle install` worked as expected locally, and updated `Gemfile.lock` constraints without updating the actual version in use (since that just happened in #1095)

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



