### PR TITLE
remove unused gems from Gemfile (and indirectly loaded gems)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching;
 gem 'bunny', '~> 2.19' # for rabbitmq
 gem 'committee' # Validates HTTP requests/responses per OpenAPI specification
 gem 'config'
-gem 'dry-monads', '~> 1.3'
-gem 'erubis'
 gem 'faraday'
 gem 'honeybadger'
 gem 'okcomputer' # for monitoring
@@ -16,7 +14,6 @@ gem 'rack-timeout', '~> 0.5.1'
 gem 'rails', '~> 7.0.0'
 gem 'rsolr', '~> 2.0'
 gem 'sneakers', '~> 2.11'
-gem 'solrizer'
 
 # DLSS gems
 gem 'dor_indexing', '~> 1.2'
@@ -29,7 +26,6 @@ group :development, :test do
   gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 5.0'
   gem 'simplecov'
-  gem 'webmock'
 end
 
 group :development do
@@ -41,9 +37,7 @@ group :development do
 end
 
 group :deployment do
-  gem 'capistrano', '~> 3.0'
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
-  gem 'capistrano-shared_configs'
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,8 +66,6 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.5.1)
       sshkit (>= 1.6.1, != 1.7.0)
     amq-protocol (2.3.2)
@@ -125,9 +123,6 @@ GEM
     config (5.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    crack (0.4.6)
-      bigdecimal
-      rexml
     crass (1.0.6)
     date (3.3.4)
     deep_merge (1.2.2)
@@ -174,10 +169,6 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-monads (1.6.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 1.0, < 2)
-      zeitwerk (~> 2.6)
     dry-schema (1.13.3)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 1.0, >= 1.0.1)
@@ -209,7 +200,6 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.12.0)
-    erubis (2.7.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
@@ -219,7 +209,6 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    hashdiff (1.1.0)
     honeybadger (5.4.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -289,7 +278,6 @@ GEM
       racc
     patience_diff (1.2.0)
       optimist (~> 3.0)
-    public_suffix (5.0.4)
     puma (5.6.8)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -432,10 +420,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    webmock (3.19.1)
-      addressable (>= 2.8.0)
-      crack (>= 0.3.2)
-      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -454,18 +438,14 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bunny (~> 2.19)
   byebug
-  capistrano (~> 3.0)
   capistrano-bundler
   capistrano-passenger
-  capistrano-shared_configs
   committee
   config
   dlss-capistrano
   dor-services-client (~> 14.1)
   dor-workflow-client (~> 7.0)
   dor_indexing (~> 1.2)
-  dry-monads (~> 1.3)
-  erubis
   faraday
   honeybadger
   listen (~> 3.0.5)
@@ -483,8 +463,6 @@ DEPENDENCIES
   rubocop-rspec
   simplecov
   sneakers (~> 2.11)
-  solrizer
-  webmock
 
 BUNDLED WITH
    2.4.13

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,6 @@
 require 'simplecov'
 SimpleCov.start 'rails'
 
-require 'webmock/rspec'
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## Why was this change made? 🤔

I think some of these gems should have been removed when dor_indexing gem was created.  Others should never have been added.  And others are probably vestigial.

## How was this change tested? 🤨

specs and some of the integration tests 



