### PR TITLE
bump dor_indexing gem to v1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,12 +149,12 @@ GEM
       faraday-retry (~> 2.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    dor_indexing (1.3.1)
+    dor_indexing (1.4.0)
+      activesupport
       cocina-models (~> 0.95.0)
       dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
-      solrizer
       stanford-mods
       zeitwerk
     dry-configurable (1.1.0)
@@ -209,7 +209,7 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    honeybadger (5.4.1)
+    honeybadger (5.5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -395,10 +395,6 @@ GEM
       rake
       serverengine (~> 2.0.5)
       thor
-    solrizer (4.1.0)
-      activesupport
-      nokogiri
-      xml-simple
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -423,8 +419,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xml-simple (1.1.9)
-      rexml
     zeitwerk (2.6.13)
 
 PLATFORMS


### PR DESCRIPTION
## Why was this change made? 🤔

Update dor_indexing_gem to v1.4.0 to start indexing to new replacement fields (see https://github.com/sul-dlss/dor_indexing/releases/tag/v1.4.0)

## How was this change tested? 🤨

deployed to stage and ran integration tests.



