### PR TITLE
Update dependencies to pick up new dor_indexing gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (14.2.1)
+    dor-services-client (14.4.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.95.1)
       deprecation
@@ -148,9 +148,10 @@ GEM
       faraday-retry (~> 2.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    dor_indexing (1.4.1)
+    dor_indexing (1.5.0)
       activesupport
       cocina-models (~> 0.95.1)
+      dor-services-client (~> 14.0)
       dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
@@ -237,7 +238,7 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
     net-ssh (7.2.1)
     nio4r (2.7.1)
@@ -302,7 +303,7 @@ GEM
     rbtree (0.4.6)
     regexp_parser (2.9.0)
     rexml (3.2.6)
-    rsolr (2.5.0)
+    rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     rspec (3.13.0)

--- a/app/services/dor_services_client_factory.rb
+++ b/app/services/dor_services_client_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This initializes the dor-services-client with values from settings
+class DorServicesClientFactory
+  def self.build
+    Dor::Services::Client.configure(url: Settings.dor_services.url, token: Settings.dor_services.token, enable_get_retries: true)
+  end
+end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -47,7 +47,7 @@ class Indexer
 
   def build(cocina_with_metadata:)
     Honeybadger.context({ identifier: cocina_with_metadata.externalIdentifier })
-    DorIndexing.build(cocina_with_metadata:, workflow_client:, cocina_repository:)
+    DorIndexing.build(cocina_with_metadata:, workflow_client:, dor_services_client:, cocina_repository:)
   end
 
   def load_and_build(identifier:)
@@ -84,6 +84,10 @@ class Indexer
 
   def workflow_client
     @workflow_client ||= WorkflowClientFactory.build
+  end
+
+  def dor_services_client
+    @dor_services_client ||= DorServicesClientFactory.build
   end
 
   def cocina_repository

--- a/spec/requests/dor_requests_spec.rb
+++ b/spec/requests/dor_requests_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe 'DOR' do
     before do
       allow(Logger).to receive(:new).and_return(mock_logger)
       allow(RSolr).to receive(:connect).and_return(mock_solr_conn)
-      allow(DorIndexing).to receive(:build).with(cocina_with_metadata: cocina, workflow_client: Dor::Workflow::Client, cocina_repository: CocinaRepository).and_return(mock_solr_doc)
+      allow(DorIndexing).to receive(:build).with(
+        cocina_with_metadata: cocina,
+        workflow_client: Dor::Workflow::Client,
+        dor_services_client: Dor::Services::Client,
+        cocina_repository: CocinaRepository
+      ).and_return(mock_solr_doc)
       allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_service)
     end
 

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe Indexer do
 
       it 'is properly indexed' do
         expect(load_and_build).to eq(doc)
-        expect(DorIndexing).to have_received(:build).with(cocina_with_metadata: model, workflow_client: Dor::Workflow::Client, cocina_repository: CocinaRepository)
+        expect(DorIndexing).to have_received(:build).with(
+          cocina_with_metadata: model,
+          workflow_client: Dor::Workflow::Client,
+          dor_services_client: Dor::Services::Client,
+          cocina_repository: CocinaRepository
+        )
       end
     end
 
@@ -65,7 +70,12 @@ RSpec.describe Indexer do
 
       it 'is properly indexed' do
         expect(load_and_index).to eq(doc)
-        expect(DorIndexing).to have_received(:build).with(cocina_with_metadata: model, workflow_client: Dor::Workflow::Client, cocina_repository: CocinaRepository)
+        expect(DorIndexing).to have_received(:build).with(
+          cocina_with_metadata: model,
+          workflow_client: Dor::Workflow::Client,
+          dor_services_client: Dor::Services::Client,
+          cocina_repository: CocinaRepository
+        )
         expect(solr).to have_received(:add).with(doc, { add_attributes: { commitWithin: 1000 } })
       end
     end
@@ -102,7 +112,12 @@ RSpec.describe Indexer do
 
     it 'updates solr' do
       expect(reindex).to eq(doc)
-      expect(DorIndexing).to have_received(:build).with(cocina_with_metadata: model, workflow_client: Dor::Workflow::Client, cocina_repository: CocinaRepository)
+      expect(DorIndexing).to have_received(:build).with(
+        cocina_with_metadata: model,
+        workflow_client: Dor::Workflow::Client,
+        dor_services_client: Dor::Services::Client,
+        cocina_repository: CocinaRepository
+      )
       expect(solr).to have_received(:add).with(doc, { add_attributes: { commitWithin: 1000 } })
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Bump dependencies to pick up dor_indexing 1.5.0

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that exercise indexing*** (e.g. searches in Argo for newly created/updated items, access_indexing_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



